### PR TITLE
Fase 3: permisos y seguridad verificables

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -1,0 +1,23 @@
+name: Security baseline
+
+on:
+  push:
+    branches: [master, 'codex/**']
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  static-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - name: Validate PHP syntax
+        run: find Blue-Cat/assets/api Blue-Cat/scripts -name '*.php' -print0 | xargs -0 -n1 php -l
+      - name: Verify security baseline
+        run: php Blue-Cat/scripts/verify-security-baseline.php

--- a/Blue-Cat/.env.example
+++ b/Blue-Cat/.env.example
@@ -17,13 +17,15 @@ APP_NAME=Blue-Cat ERP
 APP_ENV=production
 APP_DEBUG=false
 APP_URL=https://erp.dominio.com
+FORCE_HTTPS=true
 APP_TIMEZONE=America/Santiago
 APP_LOCALE=es_CL
 
 # =============================================================================
 # SEGURIDAD
 # =============================================================================
-# Generar con: php -r "echo bin2hex(random_bytes(32));"
+# Generar una clave única sin mostrarla en consola:
+# php scripts/ensure-app-key.php
 APP_KEY=
 SESSION_LIFETIME=120
 BCRYPT_ROUNDS=12

--- a/Blue-Cat/.htaccess
+++ b/Blue-Cat/.htaccess
@@ -3,8 +3,18 @@ Options -Indexes
 
 <IfModule mod_rewrite.c>
   RewriteEngine On
+  RewriteRule ^(?:database|storage|scripts|docs)(?:/|$) - [F,L,NC]
+  RewriteRule ^\.git(?:/|$) - [F,L,NC]
 </IfModule>
 
 <FilesMatch "^(\.env|composer\.(json|lock)|package(-lock)?\.json)$">
   Require all denied
 </FilesMatch>
+
+<IfModule mod_headers.c>
+  Header always set X-Content-Type-Options "nosniff"
+  Header always set X-Frame-Options "DENY"
+  Header always set Referrer-Policy "same-origin"
+  Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
+  Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+</IfModule>

--- a/Blue-Cat/assets/api/_db.php
+++ b/Blue-Cat/assets/api/_db.php
@@ -4,6 +4,7 @@ date_default_timezone_set('America/Santiago');
 require_once __DIR__ . '/env_loader.php';
 $configuredEnv = getenv('BLUECAT_ENV_FILE');
 loadEnv($configuredEnv !== false && $configuredEnv !== '' ? $configuredEnv : dirname(__DIR__, 2) . '/.env');
+require_once __DIR__ . '/_security.php';
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Blue-Cat ERP v1.0 — Core Database Helper
@@ -61,17 +62,14 @@ function json($data, int $code = 200): void {
 
 // ── Session / Auth Helpers ───────────────────────────────────────────────────
 
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
-
 function getSessionUserId(): int {
     return isset($_SESSION['user_id']) ? (int) $_SESSION['user_id'] : 0;
 }
 
 function requireUser(): int {
     $uid = getSessionUserId();
-    if ($uid === 0) {
+    if ($uid === 0 || !securityValidateSession(getDB(), $uid)) {
+        if ($uid > 0) securityDestroySession();
         http_response_code(401);
         header('Content-Type: application/json; charset=utf-8');
         echo json_encode([
@@ -94,6 +92,10 @@ function makeJsonInputObject(array $data): ArrayObject {
 }
 
 function getJsonInput(): ?ArrayObject {
+    $declaredLength = (int)($_SERVER['CONTENT_LENGTH'] ?? 0);
+    if ($declaredLength > 4 * 1024 * 1024) {
+        json(['error'=>true,'message'=>'La solicitud supera el limite de 4 MB.'], 413);
+    }
     $raw = file_get_contents('php://input');
     $testJson = getenv('BLUECAT_TEST_JSON');
     $testJsonFile = getenv('BLUECAT_TEST_JSON_FILE');
@@ -109,6 +111,9 @@ function getJsonInput(): ?ArrayObject {
     }
     if ($raw === false || trim($raw) === '') {
         return null;
+    }
+    if (strlen($raw) > 4 * 1024 * 1024) {
+        json(['error'=>true,'message'=>'La solicitud supera el limite de 4 MB.'], 413);
     }
     $data = json_decode($raw, true);
     return (json_last_error() === JSON_ERROR_NONE && is_array($data)) ? makeJsonInputObject($data) : null;
@@ -156,6 +161,13 @@ function verificarPermiso(string $modulo, string $accion): bool {
     }
 
     return $granted;
+}
+
+function requirePermission(string $modulo, string $accion): void {
+    requireUser();
+    if (!verificarPermiso($modulo, $accion)) {
+        json(['error'=>true,'message'=>"Permiso denegado: {$modulo}.{$accion}"], 403);
+    }
 }
 
 // ── Audit Logger ─────────────────────────────────────────────────────────────

--- a/Blue-Cat/assets/api/_security.php
+++ b/Blue-Cat/assets/api/_security.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+
+function securityIsHttps(): bool
+{
+    return (!empty($_SERVER['HTTPS']) && strtolower((string)$_SERVER['HTTPS']) !== 'off')
+        || (string)($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https';
+}
+
+function securityStartSession(): void
+{
+    if (session_status() !== PHP_SESSION_NONE) return;
+    $secure = securityIsHttps();
+    ini_set('session.use_only_cookies', '1');
+    ini_set('session.use_strict_mode', '1');
+    ini_set('session.cookie_httponly', '1');
+    ini_set('session.cookie_samesite', 'Lax');
+    ini_set('session.cookie_secure', $secure ? '1' : '0');
+    session_name('BLUECATSESSID');
+    session_set_cookie_params([
+        'lifetime' => 0, 'path' => '/', 'domain' => '', 'secure' => $secure,
+        'httponly' => true, 'samesite' => 'Lax',
+    ]);
+    session_start();
+}
+
+function securityHeaders(): void
+{
+    if (headers_sent()) return;
+    header('X-Content-Type-Options: nosniff');
+    header('X-Frame-Options: DENY');
+    header('Referrer-Policy: same-origin');
+    header('Permissions-Policy: camera=(), microphone=(), geolocation=()');
+    header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' data: https://cdnjs.cloudflare.com; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'");
+    if (securityIsHttps()) header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+}
+
+function securityRequireTransport(): void
+{
+    $forceHttps = filter_var((string)(getenv('FORCE_HTTPS') ?: 'false'), FILTER_VALIDATE_BOOLEAN);
+    if (!$forceHttps || securityIsHttps()) return;
+    http_response_code(426);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode([
+        'error' => true,
+        'code' => 'HTTPS_REQUIRED',
+        'message' => 'Este servidor requiere una conexión HTTPS confiable.',
+    ], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function securityClientIp(): string
+{
+    return substr((string)($_SERVER['REMOTE_ADDR'] ?? 'local'), 0, 45);
+}
+
+function securityHash(string $value): string
+{
+    $key = trim((string)(getenv('APP_KEY') ?: ''));
+    if ($key === '') {
+        if ((string)getenv('APP_ENV') !== 'test') {
+            throw new RuntimeException('APP_KEY no configurada. Ejecute scripts/ensure-app-key.php antes de iniciar Blue-Cat.');
+        }
+        $key = 'bluecat-test-only-key';
+    }
+    return hash_hmac('sha256', strtolower(trim($value)), $key);
+}
+
+function securityCsrfToken(): string
+{
+    if (empty($_SESSION['csrf_token']) || !is_string($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    $token = $_SESSION['csrf_token'];
+    if (!headers_sent()) {
+        setcookie('XSRF-TOKEN', $token, [
+            'expires' => 0, 'path' => '/', 'secure' => securityIsHttps(),
+            'httponly' => false, 'samesite' => 'Lax',
+        ]);
+    }
+    return $token;
+}
+
+function securityRequestIsSameOrigin(): bool
+{
+    $source = (string)($_SERVER['HTTP_ORIGIN'] ?? $_SERVER['HTTP_REFERER'] ?? '');
+    if ($source === '') return true;
+    $sourceHost = strtolower((string)(parse_url($source, PHP_URL_HOST) ?? ''));
+    $requestHost = strtolower(preg_replace('/:\d+$/', '', (string)($_SERVER['HTTP_HOST'] ?? '')) ?? '');
+    return $sourceHost !== '' && hash_equals($requestHost, $sourceHost);
+}
+
+function securityRequireCsrf(): void
+{
+    $method = strtoupper((string)($_SERVER['REQUEST_METHOD'] ?? 'GET'));
+    if (in_array($method, ['GET','HEAD','OPTIONS'], true)) return;
+    $token = (string)($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+    $ajax = strtolower((string)($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '')) === 'xmlhttprequest';
+    $validToken = $token !== '' && isset($_SESSION['csrf_token']) && hash_equals((string)$_SESSION['csrf_token'], $token);
+    if (securityRequestIsSameOrigin() && ($validToken || $ajax)) return;
+    http_response_code(403);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['error'=>true,'code'=>'CSRF_REJECTED','message'=>'Solicitud rechazada por proteccion CSRF. Recargue la pagina.'], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function securitySessionLifetimeSeconds(): int
+{
+    return max(300, (int)(getenv('SESSION_LIFETIME') ?: 120) * 60);
+}
+
+function securityRegisterSession(mysqli $db, int $userId): void
+{
+    $stmt = $db->prepare("SELECT u.id_cuenta,u.session_version FROM usuario u JOIN cuenta c ON c.id_cuenta=u.id_cuenta AND c.estado='ACTIVA' WHERE u.id_user=? AND u.activo=1 LIMIT 1");
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $user = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if (!$user) throw new RuntimeException('Usuario inactivo.');
+    $accountId = (int)$user['id_cuenta'];
+    $version = (int)$user['session_version'];
+    $sessionHash = securityHash(session_id());
+    $ipHash = securityHash(securityClientIp());
+    $uaHash = securityHash((string)($_SERVER['HTTP_USER_AGENT'] ?? 'local'));
+    $expires = date('Y-m-d H:i:s', time() + securitySessionLifetimeSeconds());
+    $stmt = $db->prepare('INSERT INTO core_sesion (id_cuenta,id_user,session_hash,session_version,ip_hash,user_agent_hash,expires_at) VALUES (?,?,?,?,?,?,?)');
+    $stmt->bind_param('iisisss', $accountId, $userId, $sessionHash, $version, $ipHash, $uaHash, $expires);
+    $stmt->execute();
+    $stmt->close();
+    $_SESSION['security_session_hash'] = $sessionHash;
+    $_SESSION['last_activity_at'] = time();
+}
+
+function securityValidateSession(mysqli $db, int $userId): bool
+{
+    $now = time();
+    $last = (int)($_SESSION['last_activity_at'] ?? 0);
+    if ($last > 0 && ($now - $last) > securitySessionLifetimeSeconds()) return false;
+    $sessionHash = (string)($_SESSION['security_session_hash'] ?? securityHash(session_id()));
+    try {
+        $stmt = $db->prepare(
+            "SELECT cs.id_sesion FROM core_sesion cs JOIN usuario u ON u.id_user=cs.id_user
+             JOIN cuenta c ON c.id_cuenta=u.id_cuenta
+             WHERE cs.session_hash=? AND cs.id_user=? AND cs.revoked_at IS NULL AND cs.expires_at>NOW()
+               AND cs.session_version=u.session_version AND u.activo=1 AND c.estado='ACTIVA' LIMIT 1"
+        );
+        $stmt->bind_param('si', $sessionHash, $userId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if (!$row) return getenv('APP_ENV') === 'test' && getenv('BLUECAT_TEST_SESSION') === '1';
+        $expires = date('Y-m-d H:i:s', $now + securitySessionLifetimeSeconds());
+        $id = (int)$row['id_sesion'];
+        $stmt = $db->prepare('UPDATE core_sesion SET last_activity_at=NOW(),expires_at=? WHERE id_sesion=?');
+        $stmt->bind_param('si', $expires, $id);
+        $stmt->execute();
+        $stmt->close();
+        $_SESSION['security_session_hash'] = $sessionHash;
+        $_SESSION['last_activity_at'] = $now;
+        return true;
+    } catch (Throwable $error) {
+        return false;
+    }
+}
+
+function securityRevokeCurrentSession(mysqli $db, int $userId, string $reason = 'LOGOUT'): void
+{
+    $hash = (string)($_SESSION['security_session_hash'] ?? securityHash(session_id()));
+    try {
+        $stmt = $db->prepare('UPDATE core_sesion SET revoked_at=NOW(),revoked_by=?,revoke_reason=? WHERE session_hash=? AND revoked_at IS NULL');
+        $stmt->bind_param('iss', $userId, $reason, $hash);
+        $stmt->execute();
+        $stmt->close();
+        $stmt = $db->prepare('UPDATE usuario u SET validar_sesion=EXISTS(SELECT 1 FROM core_sesion cs WHERE cs.id_user=u.id_user AND cs.revoked_at IS NULL AND cs.expires_at>NOW()) WHERE u.id_user=?');
+        $stmt->bind_param('i', $userId);
+        $stmt->execute();
+        $stmt->close();
+    } catch (Throwable $error) {
+        // Revocation failure must not prevent local cookie destruction.
+    }
+}
+
+function securityDestroySession(): void
+{
+    $_SESSION = [];
+    if (ini_get('session.use_cookies')) {
+        $p = session_get_cookie_params();
+        setcookie(session_name(), '', [
+            'expires'=>time() - 42000, 'path'=>$p['path'], 'domain'=>$p['domain'], 'secure'=>$p['secure'],
+            'httponly'=>$p['httponly'], 'samesite'=>$p['samesite'] ?? 'Lax',
+        ]);
+        setcookie('XSRF-TOKEN', '', ['expires'=>time()-42000,'path'=>'/','secure'=>securityIsHttps(),'httponly'=>false,'samesite'=>'Lax']);
+    }
+    session_destroy();
+}
+
+function securityPasswordErrors(string $password): array
+{
+    $errors = [];
+    if (strlen($password) < 10) $errors[] = 'al menos 10 caracteres';
+    if (!preg_match('/[a-z]/', $password)) $errors[] = 'una minuscula';
+    if (!preg_match('/[A-Z]/', $password)) $errors[] = 'una mayuscula';
+    if (!preg_match('/\d/', $password)) $errors[] = 'un numero';
+    $common = ['password123','contrasena123','1234567890','qwerty12345','bluecat123'];
+    if (in_array(strtolower($password), $common, true)) $errors[] = 'una clave no comun';
+    return $errors;
+}
+
+function securityHashPassword(string $password): string
+{
+    $cost = max(10, min(14, (int)(getenv('BCRYPT_ROUNDS') ?: 12)));
+    return password_hash($password, PASSWORD_BCRYPT, ['cost'=>$cost]);
+}
+
+function securityPasswordNeedsRehash(string $hash): bool
+{
+    $cost = max(10, min(14, (int)(getenv('BCRYPT_ROUNDS') ?: 12)));
+    return password_needs_rehash($hash, PASSWORD_BCRYPT, ['cost'=>$cost]);
+}
+
+securityRequireTransport();
+securityHeaders();
+securityStartSession();
+securityCsrfToken();
+securityRequireCsrf();

--- a/Blue-Cat/assets/api/auth.php
+++ b/Blue-Cat/assets/api/auth.php
@@ -13,20 +13,64 @@ function authError(string $mensaje, int $status): void {
     json(['ok' => false, 'error' => true, 'mensaje' => $mensaje, 'message' => $mensaje], $status);
 }
 
+function authRecordAttempt(mysqli $conn, string $identity, string $result): void {
+    try {
+        $identityHash = securityHash($identity);
+        $ipHash = securityHash(securityClientIp());
+        $stmt = $conn->prepare('INSERT INTO auth_intento (identity_hash,ip_hash,resultado) VALUES (?,?,?)');
+        $stmt->bind_param('sss', $identityHash, $ipHash, $result);
+        $stmt->execute();
+        $stmt->close();
+    } catch (Throwable $error) {
+        // Authentication must still return a controlled response if telemetry fails.
+    }
+}
+
+function authRecentFailures(mysqli $conn, string $identity): int {
+    $identityHash = securityHash($identity);
+    $ipHash = securityHash(securityClientIp());
+    $windowStart = date('Y-m-d H:i:s', time() - 15 * 60);
+    $stmt = $conn->prepare("SELECT SUM(identity_hash=?) identity_total,SUM(ip_hash=?) ip_total FROM auth_intento WHERE resultado IN ('FALLO','BLOQUEADO') AND created_at>=?");
+    $stmt->bind_param('sss', $identityHash, $ipHash, $windowStart);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    // Identity throttling is strict; IP throttling is deliberately wider because
+    // several tills can share the same local gateway/server address.
+    return max((int)($row['identity_total'] ?? 0), intdiv((int)($row['ip_total'] ?? 0), 4));
+}
+
 if ($accion === 'login' && $method === 'POST') {
     $username = trim((string)($_POST['username'] ?? ''));
     $password = (string)($_POST['password'] ?? '');
     if ($username === '' || $password === '') authError('Usuario y contraseña son obligatorios.', 400);
 
-    $stmt = $conn->prepare('SELECT id_user,nombre,password,activo,COALESCE(intentos_fallidos,0) intentos_fallidos FROM usuario WHERE nombre=? OR correo=? LIMIT 1');
+    $maxAttempts = max(3, (int)(getenv('LOGIN_MAX_ATTEMPTS') ?: 5));
+    if (authRecentFailures($conn, $username) >= ($maxAttempts * 3)) {
+        authRecordAttempt($conn, $username, 'BLOQUEADO');
+        authError('Demasiados intentos. Espere unos minutos antes de volver a intentar.', 429);
+    }
+
+    $stmt = $conn->prepare('SELECT u.id_user,u.nombre,u.password,u.activo,COALESCE(u.intentos_fallidos,0) intentos_fallidos,u.bloqueado_hasta,c.estado cuenta_estado FROM usuario u JOIN cuenta c ON c.id_cuenta=u.id_cuenta WHERE u.nombre=? OR u.correo=? LIMIT 1');
     $stmt->bind_param('ss', $username, $username);
     $stmt->execute();
     $user = $stmt->get_result()->fetch_assoc();
     $stmt->close();
-    if (!$user || (int)$user['activo'] !== 1 || !password_verify($password, $user['password'])) {
+    if ($user && !empty($user['bloqueado_hasta']) && strtotime((string)$user['bloqueado_hasta']) > time()) {
+        authRecordAttempt($conn, $username, 'BLOQUEADO');
+        authError('Demasiados intentos. Espere unos minutos antes de volver a intentar.', 429);
+    }
+    if (!$user || (int)$user['activo'] !== 1 || $user['cuenta_estado'] !== 'ACTIVA' || !password_verify($password, $user['password'])) {
+        authRecordAttempt($conn, $username, 'FALLO');
         if ($user) {
-            $stmt = $conn->prepare('UPDATE usuario SET intentos_fallidos=COALESCE(intentos_fallidos,0)+1 WHERE id_user=?');
-            $id = (int)$user['id_user']; $stmt->bind_param('i', $id); $stmt->execute(); $stmt->close();
+            $attempts = (int)$user['intentos_fallidos'] + 1;
+            $lockSeconds = max(60, (int)(getenv('LOGIN_LOCKOUT_TIME') ?: 300));
+            $blockedUntil = $attempts >= $maxAttempts ? date('Y-m-d H:i:s', time() + min(3600, $lockSeconds * max(1, $attempts - $maxAttempts + 1))) : null;
+            $stmt = $conn->prepare('UPDATE usuario SET intentos_fallidos=?,ultimo_fallo_login=NOW(),bloqueado_hasta=? WHERE id_user=?');
+            $id = (int)$user['id_user'];
+            $stmt->bind_param('isi', $attempts, $blockedUntil, $id);
+            $stmt->execute();
+            $stmt->close();
         }
         authError('Usuario o contraseña incorrectos.', 401);
     }
@@ -35,9 +79,18 @@ if ($accion === 'login' && $method === 'POST') {
     $uid = (int)$user['id_user'];
     $_SESSION['user_id'] = $uid;
     $_SESSION['user_name'] = $user['nombre'];
-    $stmt = $conn->prepare('UPDATE usuario SET validar_sesion=1,ultimo_acceso=NOW(),intentos_fallidos=0 WHERE id_user=?');
-    $stmt->bind_param('i', $uid); $stmt->execute(); $stmt->close();
-    authOk('Inicio de sesión exitoso.', ['id_user'=>$uid,'nombre'=>$user['nombre']]);
+    if (securityPasswordNeedsRehash((string)$user['password'])) {
+        $newHash=securityHashPassword($password);
+        $stmt = $conn->prepare('UPDATE usuario SET password=?,validar_sesion=1,ultimo_acceso=NOW(),intentos_fallidos=0,bloqueado_hasta=NULL,ultimo_fallo_login=NULL WHERE id_user=?');
+        $stmt->bind_param('si', $newHash, $uid);
+    } else {
+        $stmt = $conn->prepare('UPDATE usuario SET validar_sesion=1,ultimo_acceso=NOW(),intentos_fallidos=0,bloqueado_hasta=NULL,ultimo_fallo_login=NULL WHERE id_user=?');
+        $stmt->bind_param('i', $uid);
+    }
+    $stmt->execute(); $stmt->close();
+    securityRegisterSession($conn, $uid);
+    authRecordAttempt($conn, $username, 'EXITO');
+    authOk('Inicio de sesión exitoso.', ['id_user'=>$uid,'nombre'=>$user['nombre'],'csrf_token'=>securityCsrfToken()]);
 }
 
 if ($accion === 'registrar' && $method === 'POST') {
@@ -46,17 +99,21 @@ if ($accion === 'registrar' && $method === 'POST') {
     $password = (string)($_POST['new-password'] ?? '');
     $confirm = (string)($_POST['confirm-password'] ?? '');
     if ($nombre === '' || !filter_var($correo, FILTER_VALIDATE_EMAIL)) authError('Nombre y correo válido son obligatorios.', 400);
-    if ($password !== $confirm || strlen($password) < 8) authError('Las contraseñas deben coincidir y tener al menos 8 caracteres.', 400);
+    if ($password !== $confirm) authError('Las contraseñas no coinciden.', 400);
+    $passwordErrors = securityPasswordErrors($password);
+    if ($passwordErrors) authError('La contraseña requiere '.implode(', ', $passwordErrors).'.', 400);
     $total = (int)$conn->query('SELECT COUNT(*) total FROM usuario')->fetch_assoc()['total'];
-    if ($total > 0 && getSessionUserId() === 0) authError('La instalación ya fue inicializada. Cree empleados desde Administración.', 403);
-    if ($total > 0 && !verificarPermiso('usuarios','editar_cuentas')) authError('No tiene permiso para crear usuarios.', 403);
+    if ($total > 0) {
+        requireUser();
+        if (!verificarPermiso('usuarios','editar_cuentas')) authError('No tiene permiso para crear usuarios.', 403);
+    }
 
     $stmt = $conn->prepare('SELECT COUNT(*) total FROM usuario WHERE nombre=? OR correo=?');
     $stmt->bind_param('ss',$nombre,$correo); $stmt->execute();
     $exists=(int)$stmt->get_result()->fetch_assoc()['total']; $stmt->close();
     if ($exists) authError('El usuario o correo ya existe.',409);
 
-    $hash=password_hash($password,PASSWORD_DEFAULT);
+    $hash=securityHashPassword($password);
     $conn->begin_transaction();
     try {
         if ($total === 0) {
@@ -92,18 +149,14 @@ if ($accion === 'estado' && $method === 'GET') {
     json(['ok'=>true,'validar_sesion'=>(int)$row['validar_sesion']]);
 }
 
+if ($accion === 'csrf' && $method === 'GET') {
+    json(['ok'=>true,'csrf_token'=>securityCsrfToken()]);
+}
+
 if ($accion === 'logout' && $method === 'POST') {
     $uid=getSessionUserId();
-    if ($uid) {
-        $stmt=$conn->prepare('UPDATE usuario SET validar_sesion=0 WHERE id_user=?');
-        $stmt->bind_param('i',$uid); $stmt->execute(); $stmt->close();
-    }
-    $_SESSION=[];
-    if (ini_get('session.use_cookies')) {
-        $p=session_get_cookie_params();
-        setcookie(session_name(),'',time()-42000,$p['path'],$p['domain'],$p['secure'],$p['httponly']);
-    }
-    session_destroy();
+    if ($uid) securityRevokeCurrentSession($conn, $uid);
+    securityDestroySession();
     authOk('Sesión cerrada correctamente.');
 }
 

--- a/Blue-Cat/assets/api/clientes.php
+++ b/Blue-Cat/assets/api/clientes.php
@@ -5,7 +5,7 @@ $conn = getDB();
 $method = $_SERVER['REQUEST_METHOD'];
 
 function requierePermisoCliente(string $accion): void {
-    if (!verificarPermiso('crm', $accion)) json(['error'=>'Permiso denegado: crm.'.$accion], 403);
+    requirePermission('crm', $accion);
 }
 
 switch ($method) {

--- a/Blue-Cat/assets/api/core.php
+++ b/Blue-Cat/assets/api/core.php
@@ -8,33 +8,50 @@ $input = getJsonInput();
 $accion = $input['accion'] ?? $_GET['accion'] ?? '';
 
 function requierePermiso($modulo, $accion) {
-    if (!verificarPermiso($modulo, $accion)) {
-        json(['error' => 'Permiso denegado: ' . $modulo . '.' . $accion], 403);
-    }
+    requirePermission($modulo, $accion);
 }
 
 function coreLog($conn, $uid, $accion, $entidad, $id_entidad = null, $detalle = null, $nivel = 'INFO', $va = null, $vn = null) {
-    $idCuenta = tenantContext($uid)->accountId;
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
-    $vn = $detalle !== null ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : $vn;
-    $stmt = $conn->prepare("INSERT INTO core_auditoria (id_cuenta,id_user,accion,entidad,id_entidad,valor_anterior,valor_nuevo,ip,user_agent,nivel) VALUES (?,?,?,?,?,?,?,?,?,?)");
-    $stmt->bind_param("iississsss", $idCuenta, $uid, $accion, $entidad, $id_entidad, $va, $vn, $ip, $ua, $nivel);
-    $stmt->execute();
-    $stmt->close();
+    try {
+        $idCuenta = tenantContext($uid)->accountId;
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        $vn = $detalle !== null ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : $vn;
+        $stmt = $conn->prepare("INSERT INTO core_auditoria (id_cuenta,id_user,accion,entidad,id_entidad,valor_anterior,valor_nuevo,ip,user_agent,nivel) VALUES (?,?,?,?,?,?,?,?,?,?)");
+        if (!$stmt) return;
+        $stmt->bind_param("iississsss", $idCuenta, $uid, $accion, $entidad, $id_entidad, $va, $vn, $ip, $ua, $nivel);
+        $stmt->execute();
+        $stmt->close();
+    } catch (Throwable $error) {
+        // Audit telemetry never interrupts the business operation.
+    }
+}
+
+function coreIsLockoutCritical(string $module, string $action): bool {
+    return $module === 'configuracion' && in_array($action, ['gestionar_roles','gestionar_usuarios'], true);
 }
 
 
 // La navegación necesita sidebar sin acceso a Configuración. El resto de este
 // endpoint pertenece al panel administrativo y se autoriza también en servidor.
-$accionesPublicas = ['sidebar', 'validar_licencia'];
+$accionesPublicas = ['sidebar', 'validar_licencia', 'sesiones_activas', 'sesion_cerrar', 'auditoria'];
+$accionesRoles = ['roles','permisos','rol_permisos','usuario_roles','rol_crear','rol_permiso_toggle','usuario_rol_toggle'];
+$accionesUsuarios = ['usuarios','usuario_crear','usuario_editar'];
+$accionesEspecializadas = array_merge($accionesRoles,$accionesUsuarios,['usuario_cambiar_password']);
 if (!in_array($accion, $accionesPublicas, true)) {
     requierePermiso('configuracion', 'ver');
     $accionesLectura = ['dashboard','empresas','sucursales','roles','permisos','rol_permisos','usuario_roles','usuarios','monedas','impuestos','numeraciones','parametros','planes','suscripciones','modulos','plan_modulos','sesiones_activas','config_boleta'];
-    if (!in_array($accion, $accionesLectura, true)) {
+    if (!in_array($accion, $accionesLectura, true) && !in_array($accion,$accionesEspecializadas,true)) {
         requierePermiso('configuracion', 'editar');
     }
 }
+
+if (in_array($accion, $accionesRoles, true)) requierePermiso('configuracion', 'gestionar_roles');
+if (in_array($accion, $accionesUsuarios, true)) requierePermiso('configuracion', 'gestionar_usuarios');
+if ($accion === 'usuario_cambiar_password') requierePermiso('usuarios', 'restablecer_password');
+if ($accion === 'sesiones_activas') requierePermiso('seguridad', 'ver_sesiones');
+if ($accion === 'sesion_cerrar') requierePermiso('seguridad', 'revocar_sesiones');
+if ($accion === 'auditoria') requierePermiso('seguridad', 'ver_auditoria');
 
 switch ($accion) {
 
@@ -187,6 +204,12 @@ case 'rol_permiso_toggle':
     requireTenantRole($conn,$context,$id_rol,true);
     $stmt = $conn->prepare("SELECT id_rol_permiso FROM rol_permiso WHERE id_rol=? AND id_permiso=?"); $stmt->bind_param("ii", $id_rol, $id_permiso); $stmt->execute(); $r = $stmt->get_result(); $stmt->close();
     if ($r->num_rows) {
+        $stmt=$conn->prepare('SELECT modulo,accion FROM permiso WHERE id_permiso=?');$stmt->bind_param('i',$id_permiso);$stmt->execute();$permission=$stmt->get_result()->fetch_assoc();$stmt->close();
+        if ($permission && coreIsLockoutCritical($permission['modulo'],$permission['accion'])) {
+            $stmt=$conn->prepare("SELECT COUNT(DISTINCT u.id_user) total FROM usuario u JOIN usuario_rol ur ON ur.id_user=u.id_user JOIN rol_permiso rp ON rp.id_rol=ur.id_rol JOIN permiso p ON p.id_permiso=rp.id_permiso WHERE u.id_cuenta=? AND u.activo=1 AND p.modulo=? AND p.accion=? AND NOT(rp.id_rol=? AND rp.id_permiso=?)");
+            $stmt->bind_param('issii',$accountId,$permission['modulo'],$permission['accion'],$id_rol,$id_permiso);$stmt->execute();$remaining=(int)$stmt->get_result()->fetch_assoc()['total'];$stmt->close();
+            if ($remaining===0) json(['error'=>'No puede quitar el último acceso administrativo de la cuenta.'],409);
+        }
         $stmt = $conn->prepare("DELETE FROM rol_permiso WHERE id_rol=? AND id_permiso=?"); $stmt->bind_param("ii", $id_rol, $id_permiso); $stmt->execute(); $stmt->close();
         coreLog($conn, $uid, 'QUITAR_PERMISO', 'rol_permiso', null, ['id_rol' => $id_rol, 'id_permiso' => $id_permiso]);
         json(['success' => true, 'estado' => 'quitado']);
@@ -214,6 +237,9 @@ case 'usuario_rol_toggle':
     requireTenantRole($conn,$context,$id_rol,true);
     $stmt = $conn->prepare("SELECT id_usuario_rol FROM usuario_rol WHERE id_user=? AND id_rol=?"); $stmt->bind_param("ii", $uid_target, $id_rol); $stmt->execute(); $r = $stmt->get_result(); $stmt->close();
     if ($r->num_rows) {
+        $stmt=$conn->prepare("SELECT COUNT(DISTINCT u.id_user) total FROM usuario u JOIN usuario_rol ur ON ur.id_user=u.id_user JOIN rol_permiso rp ON rp.id_rol=ur.id_rol JOIN permiso p ON p.id_permiso=rp.id_permiso WHERE u.id_cuenta=? AND u.activo=1 AND p.modulo='configuracion' AND p.accion='gestionar_roles' AND NOT(ur.id_user=? AND ur.id_rol=?)");
+        $stmt->bind_param('iii',$accountId,$uid_target,$id_rol);$stmt->execute();$remainingAdmins=(int)$stmt->get_result()->fetch_assoc()['total'];$stmt->close();
+        if ($remainingAdmins===0) json(['error'=>'No puede quitar el rol del último administrador de la cuenta.'],409);
         $stmt = $conn->prepare("DELETE FROM usuario_rol WHERE id_user=? AND id_rol=?"); $stmt->bind_param("ii", $uid_target, $id_rol); $stmt->execute(); $stmt->close();
         coreLog($conn, $uid, 'QUITAR_ROL', 'usuario_rol', null, ['id_user' => $uid_target, 'id_rol' => $id_rol]);
         json(['success' => true, 'estado' => 'quitado']);
@@ -237,14 +263,16 @@ case 'usuario_crear':
     $nombre = $input['nombre'] ?? '';
     $correo = $input['correo'] ?? '';
     $password = $input['password'] ?? '';
-    if (!$nombre || !$correo || !$password) json(['error' => 'Nombre, correo y contraseña requeridos'], 400);
-    $hash = password_hash($password, PASSWORD_DEFAULT);
+    if (!$nombre || !filter_var($correo, FILTER_VALIDATE_EMAIL) || !$password) json(['error' => 'Nombre, correo válido y contraseña requeridos'], 400);
+    $passwordErrors = securityPasswordErrors((string)$password);
+    if ($passwordErrors) json(['error' => 'La contraseña requiere '.implode(', ', $passwordErrors).'.'], 400);
+    $hash = securityHashPassword((string)$password);
     $nombre_completo = $input['nombre_completo'] ?? '';
     $cargo = $input['cargo'] ?? '';
     $telefono = $input['telefono'] ?? '';
     $id_sucursal = (int)($input['id_sucursal'] ?? 0);
     $id_cuenta=$accountId; if($id_sucursal>0) requireTenantEntity($conn,$context,'sucursal',$id_sucursal);
-    $stmt = $conn->prepare("INSERT INTO usuario (nombre, correo, password, nombre_completo, cargo, telefono, id_sucursal, id_cuenta, validar_sesion) VALUES (?,?,?,?,?,?,?,?,1)");
+    $stmt = $conn->prepare("INSERT INTO usuario (nombre, correo, password, nombre_completo, cargo, telefono, id_sucursal, id_cuenta, validar_sesion, password_changed_at) VALUES (?,?,?,?,?,?,?,?,0,NOW())");
     $stmt->bind_param("ssssssii", $nombre, $correo, $hash, $nombre_completo, $cargo, $telefono, $id_sucursal, $id_cuenta);
     $stmt->execute(); $id = (int)$conn->insert_id; $stmt->close();
     coreLog($conn, $uid, 'CREAR', 'usuario', $id, ['nombre' => $nombre, 'correo' => $correo]);
@@ -255,6 +283,11 @@ case 'usuario_editar':
     $id = (int)($input['id'] ?? 0);
     requireTenantUser($conn,$context,$id);
     if (isset($input['id_sucursal']) && (int)$input['id_sucursal']>0) requireTenantEntity($conn,$context,'sucursal',(int)$input['id_sucursal']);
+    if (isset($input['activo']) && (int)$input['activo']===0) {
+        $stmt=$conn->prepare("SELECT COUNT(DISTINCT u.id_user) total FROM usuario u JOIN usuario_rol ur ON ur.id_user=u.id_user JOIN rol_permiso rp ON rp.id_rol=ur.id_rol JOIN permiso p ON p.id_permiso=rp.id_permiso WHERE u.id_cuenta=? AND u.activo=1 AND u.id_user<>? AND p.modulo='configuracion' AND p.accion='gestionar_roles'");
+        $stmt->bind_param('ii',$accountId,$id);$stmt->execute();$remainingAdmins=(int)$stmt->get_result()->fetch_assoc()['total'];$stmt->close();
+        if ($remainingAdmins===0 && verificarPermiso('configuracion','gestionar_roles')) json(['error'=>'No puede desactivar el último administrador de la cuenta.'],409);
+    }
     $allowed = ['nombre_completo', 'cargo', 'telefono', 'id_sucursal', 'id_departamento', 'idioma', 'activo'];
     $fields = []; $params = []; $types = '';
     foreach ($input as $k => $v) { if (in_array($k, $allowed)) { $fields[] = "$k=?"; $params[] = $v; $types .= 's'; } }
@@ -269,16 +302,20 @@ case 'usuario_editar':
     break;
 
 case 'usuario_cambiar_password':
-    requierePermiso('usuarios', 'editar_cuentas');
     $id = (int)($input['id_user'] ?? 0);
     $password = $input['password'] ?? '';
     if (!$id || !$password) json(['error' => 'Datos incompletos'], 400);
     requireTenantUser($conn,$context,$id);
-    if (strlen($password) < 6) json(['error' => 'La contraseña debe tener al menos 6 caracteres'], 400);
+    $passwordErrors = securityPasswordErrors((string)$password);
+    if ($passwordErrors) json(['error' => 'La contraseña requiere '.implode(', ', $passwordErrors).'.'], 400);
     
-    $hash = password_hash($password, PASSWORD_DEFAULT);
-    $stmt = $conn->prepare("UPDATE usuario SET password=? WHERE id_user=? AND id_cuenta={$accountId}");
+    $hash = securityHashPassword((string)$password);
+    $stmt = $conn->prepare("UPDATE usuario SET password=?,password_changed_at=NOW(),session_version=session_version+1,validar_sesion=0,intentos_fallidos=0,bloqueado_hasta=NULL,ultimo_fallo_login=NULL WHERE id_user=? AND id_cuenta={$accountId}");
     $stmt->bind_param("si", $hash, $id);
+    $stmt->execute();
+    $stmt->close();
+    $stmt = $conn->prepare("UPDATE core_sesion SET revoked_at=NOW(),revoked_by=?,revoke_reason='PASSWORD_RESET' WHERE id_user=? AND id_cuenta=? AND revoked_at IS NULL");
+    $stmt->bind_param('iii', $uid, $id, $accountId);
     $stmt->execute();
     $stmt->close();
     coreLog($conn, $uid, 'CAMBIAR_PASSWORD', 'usuario', $id, ['password_changed' => true]);
@@ -395,11 +432,11 @@ case 'auditoria':
     $offset = ($page - 1) * $limit;
     $nivel = $input['nivel'] ?? $_GET['nivel'] ?? '';
     if ($nivel) {
-        $stmt = $conn->prepare("SELECT COUNT(*) AS t FROM core_auditoria WHERE nivel=?"); $stmt->bind_param("s", $nivel); $stmt->execute(); $total = (int)$stmt->get_result()->fetch_assoc()['t']; $stmt->close();
-        $stmt = $conn->prepare("SELECT a.*, u.nombre AS user_nombre FROM core_auditoria a LEFT JOIN usuario u ON a.id_user=u.id_user WHERE nivel=? ORDER BY a.created_at DESC LIMIT ? OFFSET ?"); $stmt->bind_param("sii", $nivel, $limit, $offset);
+        $stmt = $conn->prepare("SELECT COUNT(*) AS t FROM core_auditoria WHERE id_cuenta=? AND nivel=?"); $stmt->bind_param("is", $accountId, $nivel); $stmt->execute(); $total = (int)$stmt->get_result()->fetch_assoc()['t']; $stmt->close();
+        $stmt = $conn->prepare("SELECT a.*, u.nombre AS user_nombre FROM core_auditoria a LEFT JOIN usuario u ON a.id_user=u.id_user WHERE a.id_cuenta=? AND a.nivel=? ORDER BY a.created_at DESC LIMIT ? OFFSET ?"); $stmt->bind_param("isii", $accountId, $nivel, $limit, $offset);
     } else {
-        $stmt = $conn->prepare("SELECT COUNT(*) AS t FROM core_auditoria"); $stmt->execute(); $total = (int)$stmt->get_result()->fetch_assoc()['t']; $stmt->close();
-        $stmt = $conn->prepare("SELECT a.*, u.nombre AS user_nombre FROM core_auditoria a LEFT JOIN usuario u ON a.id_user=u.id_user ORDER BY a.created_at DESC LIMIT ? OFFSET ?"); $stmt->bind_param("ii", $limit, $offset);
+        $stmt = $conn->prepare("SELECT COUNT(*) AS t FROM core_auditoria WHERE id_cuenta=?"); $stmt->bind_param('i', $accountId); $stmt->execute(); $total = (int)$stmt->get_result()->fetch_assoc()['t']; $stmt->close();
+        $stmt = $conn->prepare("SELECT a.*, u.nombre AS user_nombre FROM core_auditoria a LEFT JOIN usuario u ON a.id_user=u.id_user WHERE a.id_cuenta=? ORDER BY a.created_at DESC LIMIT ? OFFSET ?"); $stmt->bind_param("iii", $accountId, $limit, $offset);
     }
     $stmt->execute(); $items = []; $r = $stmt->get_result(); while ($f = $r->fetch_assoc()) $items[] = $f; $stmt->close();
     json(['items' => $items, 'total' => $total, 'page' => $page]);
@@ -433,7 +470,7 @@ case 'plan_crear':
 
 // ═══ SUSCRIPCIONES ═══
 case 'suscripciones':
-    $items = []; $r = $conn->query("SELECT s.*, p.nombre AS plan_nombre, e.razon_social AS empresa FROM suscripcion s JOIN plan p ON s.id_plan=p.id_plan JOIN empresa e ON s.id_empresa=e.id_empresa ORDER BY s.created_at DESC");
+    $items = []; $r = $conn->query("SELECT s.*, p.nombre AS plan_nombre, e.razon_social AS empresa FROM suscripcion s JOIN plan p ON s.id_plan=p.id_plan JOIN empresa e ON s.id_empresa=e.id_empresa WHERE e.id_cuenta={$accountId} ORDER BY s.created_at DESC");
     while ($f = $r->fetch_assoc()) $items[] = $f;
     json($items);
     break;
@@ -441,9 +478,10 @@ case 'suscripciones':
 case 'suscripcion_crear':
     $id_empresa_s = (int)($input['id_empresa'] ?? 0); $id_plan_s = (int)($input['id_plan'] ?? 0);
     if (!$id_empresa_s || !$id_plan_s) json(['error' => 'Empresa y plan requeridos'], 400);
+    requireTenantEntity($conn,$context,'empresa',$id_empresa_s);
     $stmt2 = $conn->prepare("SELECT max_usuarios FROM plan WHERE id_plan=?"); $stmt2->bind_param("i", $id_plan_s); $stmt2->execute(); $r = $stmt2->get_result()->fetch_assoc(); $stmt2->close();
     $max_users = (int)($r['max_usuarios'] ?? 0);
-    $r = $conn->query("SELECT COUNT(*) as t FROM usuario WHERE activo=1");
+    $r = $conn->query("SELECT COUNT(*) as t FROM usuario WHERE id_cuenta={$accountId} AND activo=1");
     $current = (int)$r->fetch_assoc()['t'];
     if ($current > $max_users) json(['error' => "Límite de usuarios excedido ($current/$max_users). Desactive usuarios o aumente el plan."], 400);
     $stmt = $conn->prepare("INSERT INTO suscripcion (id_empresa, id_plan, fecha_inicio, estado) VALUES (?,?,CURDATE(),'activa') ON DUPLICATE KEY UPDATE id_plan=?, estado='activa'");
@@ -541,9 +579,15 @@ case 'sidebar':
 
 // ═══ LICENCIA ═══
 case 'validar_licencia':
-    $r = $conn->query("SELECT COALESCE(p.max_usuarios + COALESCE(s.usuarios_extra,0), 5) AS max_u, 
-        (SELECT COUNT(*) FROM usuario WHERE activo=1) AS current_u
-        FROM plan p JOIN suscripcion s ON p.id_plan=s.id_plan WHERE s.estado='activa' LIMIT 1")->fetch_assoc();
+    $stmt = $conn->prepare("SELECT COALESCE(MAX(p.max_usuarios + COALESCE(s.usuarios_extra,0)),5) AS max_u,
+        (SELECT COUNT(*) FROM usuario WHERE id_cuenta=? AND activo=1) AS current_u
+        FROM plan p JOIN suscripcion s ON p.id_plan=s.id_plan
+        JOIN empresa e ON e.id_empresa=s.id_empresa
+        WHERE e.id_cuenta=? AND s.estado='activa'");
+    $stmt->bind_param('ii', $accountId, $accountId);
+    $stmt->execute();
+    $r = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
     $disponible = max(0, (int)$r['max_u'] - (int)$r['current_u']);
     json(['max_usuarios' => (int)$r['max_u'], 'actual' => (int)$r['current_u'], 'disponible' => $disponible, 'puede_crear' => $disponible > 0]);
     break;
@@ -551,19 +595,28 @@ case 'validar_licencia':
 // ═══ SESIONES ACTIVAS ═══
 case 'sesiones_activas':
     $items = [];
-    $r = $conn->query("SELECT sl.id_sesion_log, sl.id_user, u.nombre, u.nombre_completo, sl.accion, sl.ip, sl.created_at 
-        FROM sesion_log sl LEFT JOIN usuario u ON sl.id_user=u.id_user 
-        WHERE sl.created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
-        ORDER BY sl.created_at DESC LIMIT 100");
+    $stmt = $conn->prepare("SELECT cs.id_sesion,cs.id_user,u.nombre,u.nombre_completo,
+        CASE WHEN cs.revoked_at IS NULL AND cs.expires_at>NOW() THEN 'ACTIVA' ELSE 'CERRADA' END accion,
+        cs.created_at,cs.last_activity_at,cs.expires_at,cs.revoked_at,cs.revoke_reason
+        FROM core_sesion cs JOIN usuario u ON u.id_user=cs.id_user
+        WHERE cs.id_cuenta=? ORDER BY cs.last_activity_at DESC LIMIT 100");
+    $stmt->bind_param('i', $accountId);
+    $stmt->execute();
+    $r = $stmt->get_result();
     while ($f = $r->fetch_assoc()) $items[] = $f;
+    $stmt->close();
     json($items);
     break;
 
 case 'sesion_cerrar':
     $id_sesion = (int)($input['id_sesion'] ?? 0);
     if (!$id_sesion) json(['error'=>'ID requerido'],400);
-    $stmt = $conn->prepare("UPDATE sesion_log SET accion=CONCAT(accion,'_CERRADA') WHERE id_sesion_log=?"); $stmt->bind_param("i", $id_sesion); $stmt->execute(); $stmt->close();
-    coreLog($conn, $uid, 'CERRAR_SESION', 'sesion_log', $id_sesion);
+    $stmt = $conn->prepare("UPDATE core_sesion SET revoked_at=NOW(),revoked_by=?,revoke_reason='ADMIN_REVOKE' WHERE id_sesion=? AND id_cuenta=? AND revoked_at IS NULL");
+    $stmt->bind_param("iii", $uid, $id_sesion, $accountId);
+    $stmt->execute();
+    if ($stmt->affected_rows !== 1) { $stmt->close(); json(['error'=>'Sesión no encontrada o ya cerrada'],404); }
+    $stmt->close();
+    coreLog($conn, $uid, 'CERRAR_SESION', 'core_sesion', $id_sesion);
     json(['success'=>true]);
     break;
 

--- a/Blue-Cat/assets/api/crm.php
+++ b/Blue-Cat/assets/api/crm.php
@@ -7,18 +7,15 @@ $input = getJsonInput();
 $accion = $input['accion'] ?? '';
 
 function crmLog($conn, $uid, $accion, $entidad, $id_entidad = null, $detalle = null, $nivel = 'INFO') {
-    $det = $detalle ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : null;
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $stmt = $conn->prepare("INSERT INTO cliente_auditoria (id_user, accion, entidad, id_entidad, valor_nuevo, ip, nivel) VALUES (?,?,?,?,?,?,?)");
-    $stmt->bind_param("ississs", $uid, $accion, $entidad, $id_entidad, $det, $ip, $nivel);
-    $stmt->execute();
-    $stmt->close();
+    try {
+        $det = $detalle ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : null;$ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $stmt = $conn->prepare("INSERT INTO cliente_auditoria (id_user, accion, entidad, id_entidad, valor_nuevo, ip, nivel) VALUES (?,?,?,?,?,?,?)");
+        if(!$stmt)return;$stmt->bind_param("ississs", $uid, $accion, $entidad, $id_entidad, $det, $ip, $nivel);$stmt->execute();$stmt->close();
+    } catch(Throwable $error) { error_log('cliente_auditoria: '.$error->getMessage()); }
 }
 
 function requierePermiso($modulo, $accion) {
-    if (!verificarPermiso($modulo, $accion)) {
-        json(['error'=>'Permiso denegado: '.$modulo.'.'.$accion], 403);
-    }
+    requirePermission($modulo, $accion);
 }
 
 $crmReadActions = ['dashboard','clientes','cliente_obtener','cliente','actividades','creditos','etiquetas','cliente_etiquetas','reporte_abc','reporte_morosidad','auditoria'];

--- a/Blue-Cat/assets/api/dashboard.php
+++ b/Blue-Cat/assets/api/dashboard.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/_db.php';
 $uid = requireUser();
+requirePermission('facturas', 'ver');
 $conn = getDB();
 $tenant = tenantContext($uid);
 

--- a/Blue-Cat/assets/api/empleados.php
+++ b/Blue-Cat/assets/api/empleados.php
@@ -3,9 +3,7 @@ require_once __DIR__ . '/_db.php';
 $uid = requireUser();
 
 function requierePermiso($modulo, $accion) {
-    if (!verificarPermiso($modulo, $accion)) {
-        json(['error'=>'Permiso denegado: '.$modulo.'.'.$accion], 403);
-    }
+    requirePermission($modulo, $accion);
 }
 
 function requireEmpleadoActionScope(mysqli $conn, int $uid, string $accion, ArrayObject $input): void {
@@ -131,11 +129,11 @@ switch ($method) {
 
 /* ── HELPERS ── */
 function addAuditoria($conn, $id_empleado, $id_user, $accion, $detalle = null) {
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $stmt = $conn->prepare("INSERT INTO empleado_auditoria (id_empleado, id_user, accion, detalle, ip) VALUES (?,?,?,?,?)");
-    $stmt->bind_param("iisss", $id_empleado, $id_user, $accion, $detalle, $ip);
-    $stmt->execute();
-    $stmt->close();
+    try {
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $stmt = $conn->prepare("INSERT INTO empleado_auditoria (id_empleado, id_user, accion, detalle, ip) VALUES (?,?,?,?,?)");
+        if(!$stmt)return;$stmt->bind_param("iisss", $id_empleado, $id_user, $accion, $detalle, $ip);$stmt->execute();$stmt->close();
+    } catch(Throwable $error) { error_log('empleado_auditoria: '.$error->getMessage()); }
 }
 
 /* ── LIST ── */
@@ -1124,6 +1122,7 @@ function crearHistorial($conn, $uid, $input) {
    CREAR CREDENCIALES
    ═══════════════════════════════════════════ */
 function crearCredenciales($conn, $uid, $input) {
+    requirePermission('usuarios', 'editar_cuentas');
     $context = requireTenantContext($uid);
     $id_emp = (int)($input['id_empleado'] ?? 0);
     $correo = strtolower(trim((string)($input['correo'] ?? '')));
@@ -1132,7 +1131,8 @@ function crearCredenciales($conn, $uid, $input) {
 
     if (!$id_emp || !$correo || !$password) json(['error'=>'Empleado, correo y contraseña requeridos'], 400);
     if (!filter_var($correo, FILTER_VALIDATE_EMAIL)) json(['error'=>'Correo no válido'], 400);
-    if (strlen($password) < 6) json(['error'=>'La contraseña debe tener al menos 6 caracteres'], 400);
+    $passwordErrors = securityPasswordErrors((string)$password);
+    if ($passwordErrors) json(['error'=>'La contraseña requiere '.implode(', ', $passwordErrors).'.'], 400);
     // Validar antes de iniciar la transacción: una plantilla global no se puede
     // asignar y no debe provocar una creación parcial seguida de rollback.
     if ($id_rol) requireTenantRole($conn, $context, $id_rol, true);
@@ -1159,7 +1159,7 @@ function crearCredenciales($conn, $uid, $input) {
 
     $conn->begin_transaction();
     try {
-        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $hash = securityHashPassword((string)$password);
         $nombre_completo = $emp['nombres'] . ' ' . $emp['apellidos'];
         $baseUsername = preg_replace('/[^a-zA-Z0-9._-]/', '', explode('@', $correo)[0]);
         if ($baseUsername === '') $baseUsername = 'usuario';
@@ -1170,7 +1170,7 @@ function crearCredenciales($conn, $uid, $input) {
 
         $idCuenta = $context->accountId;
         $idSucursal = $context->branchId;
-        $stmt = $conn->prepare("INSERT INTO usuario (nombre, correo, password, nombre_completo, activo, validar_sesion, id_empleado, id_cuenta, id_sucursal) VALUES (?,?,?,?,1,1,?,?,?)");
+        $stmt = $conn->prepare("INSERT INTO usuario (nombre, correo, password, nombre_completo, activo, validar_sesion, id_empleado, id_cuenta, id_sucursal, password_changed_at) VALUES (?,?,?,?,1,0,?,?,?,NOW())");
         $stmt->bind_param("ssssiii", $username, $correo, $hash, $nombre_completo, $id_emp, $idCuenta, $idSucursal);
         $stmt->execute();
         $id_user = (int)$conn->insert_id;
@@ -1221,8 +1221,13 @@ function eliminarEmpleado($conn, $uid, $input) {
     $conn->begin_transaction();
     try {
         // Desactivar solo la credencial propia del empleado, nunca al usuario propietario.
-        $stmt = $conn->prepare("UPDATE usuario SET activo=0 WHERE id_empleado = ? AND id_cuenta = ?");
+        $stmt = $conn->prepare("UPDATE usuario SET activo=0,validar_sesion=0,session_version=session_version+1 WHERE id_empleado = ? AND id_cuenta = ?");
         $stmt->bind_param("ii", $id, $context->accountId); $stmt->execute(); $stmt->close();
+        if ((int)($emp['id_user'] ?? 0) > 0) {
+            $targetUser=(int)$emp['id_user'];
+            $stmt=$conn->prepare("UPDATE core_sesion SET revoked_at=NOW(),revoked_by=?,revoke_reason='EMPLOYEE_DEACTIVATED' WHERE id_user=? AND id_cuenta=? AND revoked_at IS NULL");
+            $stmt->bind_param('iii',$uid,$targetUser,$context->accountId);$stmt->execute();$stmt->close();
+        }
         // Auditoría ANTES de eliminar
         $ip = $_SERVER['REMOTE_ADDR'] ?? '';
         $detalle = "Empleado {$emp['nombres']} {$emp['apellidos']} eliminado";
@@ -1281,25 +1286,30 @@ function vincularUsuario($conn, $uid, $input) {
 }
 
 function editarCredenciales($conn, $uid, $input) {
+    requirePermission('usuarios', 'editar_cuentas');
     $context = requireTenantContext($uid);
     $id_emp=(int)($input['id_empleado']??0); $nombre=trim($input['nombre']??''); $correo=trim($input['correo']??'');
     $password=$input['password']??''; $activo=!empty($input['activo'])?1:0;
     if(!$id_emp||$nombre==='') json(['error'=>'Empleado y usuario requeridos'],400);
     if($correo!==''&&!filter_var($correo,FILTER_VALIDATE_EMAIL)) json(['error'=>'Correo no válido'],400);
-    if($password!==''&&strlen($password)<6) json(['error'=>'La contraseña debe tener al menos 6 caracteres'],400);
+    if($password!==''){$passwordErrors=securityPasswordErrors((string)$password);if($passwordErrors)json(['error'=>'La contraseña requiere '.implode(', ',$passwordErrors).'.'],400);}
     $stmt=$conn->prepare("SELECT u.id_user FROM usuario u JOIN empleado e ON e.id_empleado=u.id_empleado AND e.id_cuenta=u.id_cuenta WHERE e.id_empleado=? AND e.id_cuenta=? LIMIT 1");
     $stmt->bind_param("ii",$id_emp,$context->accountId);$stmt->execute();$row=$stmt->get_result()->fetch_assoc();$stmt->close();
     if(!$row) json(['error'=>'Credenciales no encontradas'],404); $id_user=(int)$row['id_user'];
     $stmt=$conn->prepare("SELECT id_user FROM usuario WHERE (nombre=? OR (?<>'' AND correo=?)) AND id_user<>? LIMIT 1");
     $stmt->bind_param("sssi",$nombre,$correo,$correo,$id_user);$stmt->execute();$dup=$stmt->get_result()->fetch_assoc();$stmt->close();
     if($dup) json(['error'=>'El usuario o correo ya está registrado'],400);
-    if($password!==''){$hash=password_hash($password,PASSWORD_DEFAULT);$stmt=$conn->prepare("UPDATE usuario SET nombre=?,correo=?,password=?,activo=? WHERE id_user=? AND id_cuenta=?");$stmt->bind_param("sssiii",$nombre,$correo,$hash,$activo,$id_user,$context->accountId);}
-    else{$stmt=$conn->prepare("UPDATE usuario SET nombre=?,correo=?,activo=? WHERE id_user=? AND id_cuenta=?");$stmt->bind_param("ssiii",$nombre,$correo,$activo,$id_user,$context->accountId);}
-    $stmt->execute();$stmt->close(); addAuditoria($conn,$id_emp,$uid,'EDITAR_CREDENCIALES',"Usuario #$id_user actualizado");
+    $invalidate=0;
+    if($password!==''){$invalidate=1;$hash=securityHashPassword((string)$password);$stmt=$conn->prepare("UPDATE usuario SET nombre=?,correo=?,password=?,password_changed_at=NOW(),session_version=session_version+1,validar_sesion=0,intentos_fallidos=0,bloqueado_hasta=NULL,ultimo_fallo_login=NULL,activo=? WHERE id_user=? AND id_cuenta=?");$stmt->bind_param("sssiii",$nombre,$correo,$hash,$activo,$id_user,$context->accountId);}
+    else{$stmt=$conn->prepare("UPDATE usuario SET nombre=?,correo=?,activo=?,session_version=session_version+IF(?=0,1,0),validar_sesion=IF(?=0,0,validar_sesion) WHERE id_user=? AND id_cuenta=?");$stmt->bind_param("ssiiiii",$nombre,$correo,$activo,$activo,$activo,$id_user,$context->accountId);$invalidate=$activo===0?1:0;}
+    $stmt->execute();$stmt->close();
+    if($invalidate){$stmt=$conn->prepare("UPDATE core_sesion SET revoked_at=NOW(),revoked_by=?,revoke_reason='CREDENTIAL_CHANGE' WHERE id_user=? AND id_cuenta=? AND revoked_at IS NULL");$stmt->bind_param('iii',$uid,$id_user,$context->accountId);$stmt->execute();$stmt->close();}
+    addAuditoria($conn,$id_emp,$uid,'EDITAR_CREDENCIALES',"Usuario #$id_user actualizado");
     json(['success'=>true,'usuario'=>$nombre,'correo'=>$correo,'activo'=>$activo]);
 }
 
 function eliminarCredenciales($conn, $uid, $input) {
+    requirePermission('usuarios', 'editar_cuentas');
     $context = requireTenantContext($uid);
     $id_emp=(int)($input['id_empleado']??0); if(!$id_emp) json(['error'=>'ID requerido'],400);
     $stmt=$conn->prepare("SELECT u.id_user,u.correo FROM usuario u JOIN empleado e ON e.id_empleado=u.id_empleado AND e.id_cuenta=u.id_cuenta WHERE e.id_empleado=? AND e.id_cuenta=? LIMIT 1");

--- a/Blue-Cat/assets/api/exportar.php
+++ b/Blue-Cat/assets/api/exportar.php
@@ -2,6 +2,7 @@
 header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/_db.php';
 $uid = requireUser();
+requirePermission('facturas', 'exportar');
 $conn = getDB();
 
 $formato = $_GET['formato'] ?? 'json';
@@ -17,8 +18,9 @@ if ($tipo === 'facturas' && !$id_factura) {
 }
 
 function exportFactura($conn, $uid, $id, $formato) {
-    $stmt = $conn->prepare("SELECT f.*, c.razon_social, c.rut, c.nombre as cliente_nombre, c.direccion, c.correo FROM factura f LEFT JOIN cliente c ON f.id_cliente = c.id_cliente WHERE f.id_factura = ? AND f.id_user = ?");
-    $stmt->bind_param("ii", $id, $uid);
+    $accountId = tenantContext($uid)->accountId;
+    $stmt = $conn->prepare("SELECT f.*, c.razon_social, c.rut, c.nombre as cliente_nombre, c.direccion, c.correo FROM factura f LEFT JOIN cliente c ON f.id_cliente = c.id_cliente AND c.id_cuenta=f.id_cuenta WHERE f.id_factura = ? AND f.id_cuenta = ?");
+    $stmt->bind_param("ii", $id, $accountId);
     $stmt->execute();
     $f = $stmt->get_result()->fetch_assoc();
     $stmt->close();
@@ -81,13 +83,15 @@ function exportListado($conn, $uid, $formato) {
     $desde = $_GET['desde'] ?? '';
     $hasta = $_GET['hasta'] ?? '';
 
-    $sql = "SELECT f.*, c.razon_social, c.rut FROM factura f LEFT JOIN cliente c ON f.id_cliente = c.id_cliente WHERE f.id_user = $uid";
-    if ($estado) $sql .= " AND f.estado = '" . $conn->real_escape_string($estado) . "'";
-    if ($desde)  $sql .= " AND f.fecha_emision >= '" . $conn->real_escape_string($desde) . "'";
-    if ($hasta)  $sql .= " AND f.fecha_emision <= '" . $conn->real_escape_string($hasta) . " 23:59:59'";
+    $accountId = tenantContext($uid)->accountId;
+    $sql = "SELECT f.*, c.razon_social, c.rut FROM factura f LEFT JOIN cliente c ON f.id_cliente = c.id_cliente AND c.id_cuenta=f.id_cuenta WHERE f.id_cuenta=?";
+    $params = [$accountId]; $types = 'i';
+    if ($estado) { $sql .= " AND f.estado=?"; $params[]=$estado; $types.='s'; }
+    if ($desde)  { $sql .= " AND f.fecha_emision>=?"; $params[]=$desde; $types.='s'; }
+    if ($hasta)  { $sql .= " AND f.fecha_emision<=?"; $params[]=$hasta.' 23:59:59'; $types.='s'; }
     $sql .= " ORDER BY f.id_factura DESC";
-
-    $rows = $conn->query($sql)->fetch_all(MYSQLI_ASSOC);
+    $stmt=$conn->prepare($sql);$stmt->bind_param($types,...$params);$stmt->execute();
+    $rows=$stmt->get_result()->fetch_all(MYSQLI_ASSOC);$stmt->close();
 
     if ($formato === 'csv') {
         header('Content-Type: text/csv; charset=utf-8');

--- a/Blue-Cat/assets/api/facturas.php
+++ b/Blue-Cat/assets/api/facturas.php
@@ -4,9 +4,7 @@ require_once __DIR__ . '/_pos_integrity.php';
 $uid = requireUser();
 
 function requierePermiso($modulo, $accion) {
-    if (!verificarPermiso($modulo, $accion)) {
-        json(['error'=>'Permiso denegado: '.$modulo.'.'.$accion], 403);
-    }
+    requirePermission($modulo, $accion);
 }
 
 $conn = getDB();

--- a/Blue-Cat/assets/api/importar_productos.php
+++ b/Blue-Cat/assets/api/importar_productos.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/_db.php';
 $uid = requireUser();
-if (!verificarPermiso('inventario','importar')) json(['success'=>false,'msg'=>'Permiso denegado'],403);
+requirePermission('inventario','importar');
 $conn = getDB();
 $accountId = tenantContext($uid)->accountId;
 
@@ -17,26 +17,33 @@ function importarNumero($valor) {
 if (!isset($_FILES['file'])) json(['success'=>false,'msg'=>'No se recibió ningún archivo'],400);
 $file=$_FILES['file'];
 if ($file['error']!==UPLOAD_ERR_OK) json(['success'=>false,'msg'=>'Error en la subida: código '.$file['error']],400);
+if (!is_uploaded_file($file['tmp_name'])) json(['success'=>false,'msg'=>'Carga de archivo no válida'],400);
+if ((int)$file['size']<=0 || (int)$file['size']>5*1024*1024) json(['success'=>false,'msg'=>'El archivo debe pesar entre 1 byte y 5 MB'],400);
 $type=strtolower(pathinfo($file['name'],PATHINFO_EXTENSION));
 if (!in_array($type,['csv','xls'],true)) json(['success'=>false,'msg'=>'El archivo debe ser XLS o CSV'],400);
+$mime=(new finfo(FILEINFO_MIME_TYPE))->file($file['tmp_name'])?:'';
+$allowedMime=$type==='csv'
+    ? ['text/plain','text/csv','application/csv','application/vnd.ms-excel']
+    : ['text/html','text/plain','application/vnd.ms-excel'];
+if (!in_array($mime,$allowedMime,true)) json(['success'=>false,'msg'=>'El contenido no coincide con el formato indicado'],400);
 
 $rows=[];
 if ($type==='csv') {
     $fh=fopen($file['tmp_name'],'r');
     if (!$fh) json(['success'=>false,'msg'=>'No se pudo abrir el CSV'],400);
     fgetcsv($fh);
-    while (($row=fgetcsv($fh))!==false) $rows[]=$row;
+    while (($row=fgetcsv($fh))!==false) { $rows[]=$row; if(count($rows)>50000) json(['success'=>false,'msg'=>'El archivo supera 50.000 filas'],400); }
     fclose($fh);
 } else {
     $html=file_get_contents($file['tmp_name']);
     $dom=new DOMDocument();
     libxml_use_internal_errors(true);
-    $dom->loadHTML($html,LIBXML_NOERROR|LIBXML_NOWARNING);
+    $dom->loadHTML($html,LIBXML_NOERROR|LIBXML_NOWARNING|LIBXML_NONET);
     libxml_clear_errors();
     foreach ($dom->getElementsByTagName('tr') as $tr) {
         $cells=[];
         foreach ($tr->getElementsByTagName('td') as $td) $cells[]=trim($td->textContent);
-        if ($cells) $rows[]=$cells;
+        if ($cells) { $rows[]=$cells; if(count($rows)>50000) json(['success'=>false,'msg'=>'El archivo supera 50.000 filas'],400); }
     }
 }
 if (!$rows) json(['success'=>false,'msg'=>'El archivo no contiene productos'],400);
@@ -56,7 +63,7 @@ foreach($rows as $data) {
     $codigo=trim((string)$data[2]);
     $cantidad=importarNumero($data[3]);
     $categoria=isset($data[4])?trim((string)$data[4]):'';
-    if($nombre===''||$precio===null||$cantidad===null){$errores++;continue;}
+    if($nombre===''||mb_strlen($nombre)>200||mb_strlen($codigo)>100||mb_strlen($categoria)>100||$precio===null||$precio<0||$precio>2000000000||$cantidad===null||$cantidad<0||$cantidad>1000000000){$errores++;continue;}
     if($codigo!==''){$byCode->bind_param('is',$accountId,$codigo);$byCode->execute();$result=$byCode->get_result();}
     else{$byName->bind_param('is',$accountId,$nombre);$byName->execute();$result=$byName->get_result();}
     if($result&&$result->num_rows){

--- a/Blue-Cat/assets/api/inventario.php
+++ b/Blue-Cat/assets/api/inventario.php
@@ -21,12 +21,11 @@ if (isset($rootScopeActions[$accion])) {
 
 // ========== HELPERS ==========
 function invLog($conn, $uid, $accion, $entidad, $id_entidad=null, $detalle=null) {
-    $det = $detalle ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : null;
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $stmt = $conn->prepare("INSERT INTO inventario_auditoria (id_user,accion,entidad,id_entidad,detalle,ip) VALUES (?,?,?,?,?,?)");
-    $stmt->bind_param("ississ", $uid, $accion, $entidad, $id_entidad, $det, $ip);
-    $stmt->execute();
-    $stmt->close();
+    try {
+        $det = $detalle ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : null;$ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $stmt = $conn->prepare("INSERT INTO inventario_auditoria (id_user,accion,entidad,id_entidad,detalle,ip) VALUES (?,?,?,?,?,?)");
+        if(!$stmt)return;$stmt->bind_param("ississ", $uid, $accion, $entidad, $id_entidad, $det, $ip);$stmt->execute();$stmt->close();
+    } catch(Throwable $error) { error_log('inventario_auditoria: '.$error->getMessage()); }
 }
 
 function generarCodigo($conn, $tabla, $campo, $prefijo) {
@@ -40,9 +39,7 @@ function generarCodigo($conn, $tabla, $campo, $prefijo) {
 }
 
 function requierePermiso($modulo, $accion) {
-    if (!verificarPermiso($modulo, $accion)) {
-        json(['error'=>'Permiso denegado: '.$modulo.'.'.$accion], 403);
-    }
+    requirePermission($modulo, $accion);
 }
 
 // ========== DISPATCH ==========

--- a/Blue-Cat/assets/api/pos.php
+++ b/Blue-Cat/assets/api/pos.php
@@ -41,13 +41,18 @@ function getOpenCaja($conn, $uid) {
 }
 
 function insertAuditoria($conn, $uid, $accion, $detalle, $idRef = null, $tablaRef = null) {
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $sql = "INSERT INTO pos_auditoria (id_user, accion, detalle, id_referencia, tabla_referencia, ip)
-            VALUES (?, ?, ?, ?, ?, ?)";
-    $stmt = $conn->prepare($sql);
-    $stmt->bind_param('ississ', $uid, $accion, $detalle, $idRef, $tablaRef, $ip);
-    $stmt->execute();
-    $stmt->close();
+    try {
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '';
+        $sql = "INSERT INTO pos_auditoria (id_user, accion, detalle, id_referencia, tabla_referencia, ip)
+                VALUES (?, ?, ?, ?, ?, ?)";
+        $stmt = $conn->prepare($sql);
+        if (!$stmt) return;
+        $stmt->bind_param('ississ', $uid, $accion, $detalle, $idRef, $tablaRef, $ip);
+        $stmt->execute();
+        $stmt->close();
+    } catch (Throwable $error) {
+        // Audit telemetry never interrupts checkout or cash operations.
+    }
 }
 
 // ============================================================
@@ -59,6 +64,7 @@ if ($method === 'GET') {
     if ($action !== 'permisos_usuario' && !verificarPermiso('pos','ver')) {
         json(['error'=>true,'message'=>'Permiso denegado: pos.ver'],403);
     }
+    if ($action === 'clientes') requirePermission('pos','asociar_cliente');
 
     switch ($action) {
         case 'dashboard':           GET_dashboard();          break;
@@ -81,12 +87,25 @@ if ($method === 'GET') {
             json(['error' => true, 'message' => 'Acción no válida'], 400);
     }
 } elseif ($method === 'POST') {
+    requirePermission('pos', 'ver');
     $data = getJsonInput();
     if (!$data) {
         json(['error' => true, 'message' => 'Datos JSON requeridos'], 400);
     }
     // `action` is canonical; `accion` keeps cached/legacy clients working.
     $action = $data->action ?? $data->accion ?? '';
+    $postPermissions = [
+        'caja_movimiento'=>['pos','abrir_caja'],
+        'cliente_crear'=>['crm','crear'],
+        'promociones_evaluar'=>['pos','realizar_venta'],
+        'promocion_validar'=>['pos','realizar_venta'],
+        'cotizacion_crear'=>['pos','realizar_venta'],
+        'cotizacion_eliminar'=>['pos','realizar_venta'],
+        'reserva_crear'=>['pos','realizar_venta'],
+        'reserva_cumplir'=>['pos','realizar_venta'],
+        'reserva_cancelar'=>['pos','realizar_venta'],
+    ];
+    if (isset($postPermissions[$action])) requirePermission($postPermissions[$action][0],$postPermissions[$action][1]);
 
     switch ($action) {
         case 'caja_abrir':          if (!verificarPermiso('pos','abrir_caja')) json(['error'=>true,'message'=>'Permiso denegado'],403); POST_caja_abrir($data); break;

--- a/Blue-Cat/assets/api/proveedores.php
+++ b/Blue-Cat/assets/api/proveedores.php
@@ -3,9 +3,7 @@ require_once __DIR__ . '/_db.php';
 $uid = requireUser();
 
 function requierePermiso($modulo, $accion) {
-    if (!verificarPermiso($modulo, $accion)) {
-        json(['error'=>'Permiso denegado: '.$modulo.'.'.$accion], 403);
-    }
+    requirePermission($modulo, $accion);
 }
 
 $conn = getDB();

--- a/Blue-Cat/assets/api/ventas.php
+++ b/Blue-Cat/assets/api/ventas.php
@@ -6,19 +6,16 @@ $conn = getDB();
 $method = $_SERVER['REQUEST_METHOD'];
 
 function requierePermiso($modulo, $accion) {
-    if (!verificarPermiso($modulo, $accion)) {
-        json(['error'=>'Permiso denegado: '.$modulo.'.'.$accion], 403);
-    }
+    requirePermission($modulo, $accion);
 }
 
 function auditar($conn, $uid, $accion, $entidad, $id_entidad=null, $detalle=null, $nivel='INFO') {
-    $ip = $_SERVER['REMOTE_ADDR'] ?? '';
-    $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
-    $vn = $detalle !== null ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : null;
-    $stmt = $conn->prepare("INSERT INTO core_auditoria (id_user, accion, entidad, id_entidad, valor_nuevo, ip, user_agent, nivel) VALUES (?,?,?,?,?,?,?,?)");
-    $stmt->bind_param("ississss", $uid, $accion, $entidad, $id_entidad, $vn, $ip, $ua, $nivel);
-    $stmt->execute();
-    $stmt->close();
+    try {
+        $accountId=tenantContext($uid)->accountId;$ip = $_SERVER['REMOTE_ADDR'] ?? '';$ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        $vn = $detalle !== null ? json_encode($detalle, JSON_UNESCAPED_UNICODE) : null;
+        $stmt = $conn->prepare("INSERT INTO core_auditoria (id_cuenta,id_user, accion, entidad, id_entidad, valor_nuevo, ip, user_agent, nivel) VALUES (?,?,?,?,?,?,?,?,?)");
+        if(!$stmt)return;$stmt->bind_param("iississss",$accountId,$uid,$accion,$entidad,$id_entidad,$vn,$ip,$ua,$nivel);$stmt->execute();$stmt->close();
+    } catch(Throwable $error) { error_log('ventas_auditoria: '.$error->getMessage()); }
 }
 
 function buildWhere($conn, $uid) {

--- a/Blue-Cat/assets/js/Index.js
+++ b/Blue-Cat/assets/js/Index.js
@@ -54,8 +54,8 @@ async function createAccount() {
     return;
   }
 
-  if (password.length < 6) {
-    showError(errorEl, 'La contraseña debe tener al menos 6 caracteres');
+  if (password.length < 10 || !/[a-z]/.test(password) || !/[A-Z]/.test(password) || !/\d/.test(password)) {
+    showError(errorEl, 'Use al menos 10 caracteres, una mayúscula, una minúscula y un número');
     return;
   }
 

--- a/Blue-Cat/assets/js/configuracion.js
+++ b/Blue-Cat/assets/js/configuracion.js
@@ -14,7 +14,7 @@ function apiCfg(accion, data, cb) {
 }
 function toast(msg, type) {
   var t = document.createElement('div'); t.className = 'toast toast-' + (type === 'error' ? 'err' : 'ok');
-  t.innerHTML = '<i class="fas fa-' + (type === 'error' ? 'exclamation-circle' : 'check-circle') + '"></i> ' + msg;
+  BlueCatSecurity.renderToast(t, msg, type);
   document.body.appendChild(t); requestAnimationFrame(function() { t.classList.add('show'); });
   setTimeout(function() { t.classList.remove('show'); setTimeout(function() { t.remove(); }, 300); }, 2500);
 }
@@ -68,8 +68,8 @@ function loadDashboard() {
       '<div class="stat"><span class="stat-icon amber"><i class="fas fa-percent"></i></span><div><div class="stat-num">' + d.impuestos + '</div><div class="stat-label">Impuestos</div></div></div>' +
       '<div class="stat"><span class="stat-icon green"><i class="fas fa-history"></i></span><div><div class="stat-num">' + d.auditoria_hoy + '</div><div class="stat-label">Logs hoy</div></div></div>' +
       (d.errores_hoy > 0 ? '<div class="stat"><span class="stat-icon red"><i class="fas fa-exclamation-triangle"></i></span><div><div class="stat-num">' + d.errores_hoy + '</div><div class="stat-label">Errores hoy</div></div></div>' : '');
-    document.getElementById('t-ultimos-accesos').innerHTML = (d.ultimos_accesos || []).map(function(u) { return '<tr><td>' + esc(u.nombre_completo || u.nombre) + '</td><td>' + (u.ultimo_acceso || '-') + '</td></tr>'; }).join('');
-    document.getElementById('t-ultimos-logs').innerHTML = (d.ultimos_logs || []).map(function(l) { return '<tr><td>' + l.accion + '</td><td>' + l.entidad + (l.id_entidad ? '#' + l.id_entidad : '') + '</td><td>' + l.created_at + '</td></tr>'; }).join('');
+    document.getElementById('t-ultimos-accesos').innerHTML = (d.ultimos_accesos || []).map(function(u) { return '<tr><td>' + esc(u.nombre_completo || u.nombre) + '</td><td>' + esc(u.ultimo_acceso || '-') + '</td></tr>'; }).join('');
+    document.getElementById('t-ultimos-logs').innerHTML = (d.ultimos_logs || []).map(function(l) { return '<tr><td>' + esc(l.accion) + '</td><td>' + esc(l.entidad) + (l.id_entidad ? '#' + num(l.id_entidad) : '') + '</td><td>' + esc(l.created_at) + '</td></tr>'; }).join('');
   });
 }
 
@@ -261,7 +261,7 @@ function verDetalleUsuario(uid) {
 
 function cambiarPassword(uid, uname) {
   // Verificar permiso
-  if (!hasPermissionConfig('usuarios', 'editar_cuentas')) {
+  if (!hasPermissionConfig('usuarios', 'restablecer_password')) {
     toast('No tiene permiso para editar cuentas', 'error');
     return;
   }
@@ -271,11 +271,11 @@ function cambiarPassword(uid, uname) {
     '<form onsubmit="guardarNuevaPassword(event,' + uid + ')">' +
       '<div style="margin-bottom:12px;">' +
         '<label style="display:block;font-size:13px;font-weight:600;margin-bottom:4px;">Nueva Contraseña *</label>' +
-        '<input type="password" id="np-password" required minlength="6" style="width:100%;padding:8px;border:1px solid #e2e8f0;border-radius:6px;">' +
+        '<input type="password" id="np-password" required minlength="10" style="width:100%;padding:8px;border:1px solid #e2e8f0;border-radius:6px;">' +
       '</div>' +
       '<div style="margin-bottom:12px;">' +
         '<label style="display:block;font-size:13px;font-weight:600;margin-bottom:4px;">Confirmar Contraseña *</label>' +
-        '<input type="password" id="np-confirm" required minlength="6" style="width:100%;padding:8px;border:1px solid #e2e8f0;border-radius:6px;">' +
+        '<input type="password" id="np-confirm" required minlength="10" style="width:100%;padding:8px;border:1px solid #e2e8f0;border-radius:6px;">' +
       '</div>' +
       '<div style="display:flex;gap:8px;justify-content:flex-end;margin-top:16px;">' +
         '<button type="button" class="btn btn-outline btn-sm" onclick="closeCfgModal()">Cancelar</button>' +
@@ -298,8 +298,8 @@ function guardarNuevaPassword(event, uid) {
     return;
   }
   
-  if (password.length < 6) {
-    toast('La contraseña debe tener al menos 6 caracteres', 'error');
+  if (password.length < 10 || !/[a-z]/.test(password) || !/[A-Z]/.test(password) || !/\d/.test(password)) {
+    toast('Use al menos 10 caracteres, una mayúscula, una minúscula y un número', 'error');
     return;
   }
   
@@ -314,9 +314,21 @@ function guardarNuevaPassword(event, uid) {
 }
 
 function hasPermissionConfig(modulo, accion) {
-  // Por ahora retornamos true, pero aquí se podría verificar contra los permisos del usuario
-  return true;
+  return typeof window.blueCatHasPermission === 'function' && window.blueCatHasPermission(modulo, accion);
 }
+
+document.addEventListener('bluecat:permissions-ready', function() {
+  var policies = {
+    roles: ['configuracion', 'gestionar_roles'],
+    usuarios: ['configuracion', 'gestionar_usuarios'],
+    sesiones: ['seguridad', 'ver_sesiones'],
+    auditoria: ['seguridad', 'ver_auditoria']
+  };
+  Object.keys(policies).forEach(function(section) {
+    var item = document.querySelector('.cfg-sidebar li[data-section="' + section + '"]');
+    if (item && !hasPermissionConfig(policies[section][0], policies[section][1])) item.style.display = 'none';
+  });
+});
 
 function editUsuarioRoles(uid, uname) {
   apiCfg('usuario_roles', { id_user: uid }, function(items) {
@@ -524,7 +536,7 @@ function loadAuditoria() {
   apiCfg('auditoria', { nivel: nivel, limit: 200 }, function(r) {
     document.getElementById('t-auditoria').innerHTML = (r.items || []).map(function(a) {
       var nc = a.nivel === 'ERROR' ? 'badge-danger' : (a.nivel === 'WARNING' ? 'badge-danger' : 'badge-info');
-      return '<tr><td>' + a.created_at + '</td><td>' + esc(a.user_nombre || '') + '</td><td>' + a.accion + '</td><td>' + a.entidad + '</td><td>' + (a.id_entidad || '') + '</td><td><span class="badge ' + nc + '">' + a.nivel + '</span></td></tr>';
+      return '<tr><td>' + esc(a.created_at) + '</td><td>' + esc(a.user_nombre || '') + '</td><td>' + esc(a.accion) + '</td><td>' + esc(a.entidad) + '</td><td>' + num(a.id_entidad) + '</td><td><span class="badge ' + nc + '">' + esc(a.nivel) + '</span></td></tr>';
     }).join('') || '<tr><td colspan="6"><div class="empty-state"><i class="fas fa-history"></i><p>Sin registros</p></div></td></tr>';
   });
 }
@@ -591,7 +603,10 @@ function togglePlanModulo(id_plan, id_modulo, el) {
 function loadSesiones() {
   apiCfg('sesiones_activas', {}, function(items) {
     document.getElementById('t-sesiones').innerHTML = items.map(function(s) {
-      return '<tr><td>' + esc(s.nombre_completo || s.nombre || '') + '</td><td>' + s.accion + '</td><td>' + esc(s.ip||'') + '</td><td>' + s.created_at + '</td><td><button class="btn btn-outline btn-xs" onclick="cerrarSesionRemota('+s.id_sesion_log+')"><i class="fas fa-times"></i></button></td></tr>';
+      var active = s.accion === 'ACTIVA';
+      var action = active && hasPermissionConfig('seguridad','revocar_sesiones')
+        ? '<button class="btn btn-outline btn-xs" onclick="cerrarSesionRemota('+s.id_sesion+')" title="Revocar sesión"><i class="fas fa-times"></i></button>' : '-';
+      return '<tr><td>' + esc(s.nombre_completo || s.nombre || '') + '</td><td><span class="badge '+(active?'badge-success':'badge-gray')+'">' + esc(s.accion) + '</span></td><td>Identidad protegida</td><td>' + esc(s.last_activity_at || s.created_at) + '</td><td>'+action+'</td></tr>';
     }).join('') || '<tr><td colspan="5"><div class="empty-state"><i class="fas fa-plug"></i><p>Sin sesiones recientes</p></div></td></tr>';
   });
 }

--- a/Blue-Cat/assets/js/crm.js
+++ b/Blue-Cat/assets/js/crm.js
@@ -21,7 +21,7 @@ function apiCrm(accion, data, cb) {
 function toast(msg, type) {
   var t = document.createElement('div');
   t.className = 'toast toast-' + (type === 'error' ? 'err' : 'ok');
-  t.innerHTML = '<i class="fas fa-' + (type === 'error' ? 'exclamation-circle' : 'check-circle') + '"></i> ' + msg;
+  BlueCatSecurity.renderToast(t, msg, type);
   document.body.appendChild(t);
   requestAnimationFrame(function() { t.classList.add('show'); });
   setTimeout(function() { t.classList.remove('show'); setTimeout(function() { t.remove(); }, 300); }, 2500);

--- a/Blue-Cat/assets/js/cuadre_de_ventas.js
+++ b/Blue-Cat/assets/js/cuadre_de_ventas.js
@@ -143,7 +143,7 @@ function setMoney(id, val) {
 function showToast(msg) {
   var t = document.createElement('div');
   t.className = 'pos-toast';
-  t.innerHTML = msg;
+  BlueCatSecurity.renderToast(t, msg, 'error');
   document.body.appendChild(t);
   requestAnimationFrame(function () { t.classList.add('show'); });
   setTimeout(function () { t.classList.remove('show'); setTimeout(function () { t.remove(); }, 300); }, 2500);
@@ -199,7 +199,7 @@ function renderSalesTable() {
     var canEdit = false;
 
     tr.innerHTML =
-      '<td' + anuladoStyle + '>' + v.id_pedido + anuladoBadge + ' <span style="font-size:10px;color:#94a3b8;">' + (v.cliente_nombre || 'CF') + '</span></td>' +
+      '<td' + anuladoStyle + '>' + Number(v.id_pedido || 0) + anuladoBadge + ' <span style="font-size:10px;color:#94a3b8;">' + escapeHtml(v.cliente_nombre || 'CF') + '</span></td>' +
       '<td class="items-cell"' + anuladoStyle + '>' + itemsHtml + '</td>' +
       '<td' + anuladoStyle + '><strong>$' + (v.precio_total || 0) + '</strong></td>' +
       '<td class="pagos-cell"' + anuladoStyle + '>' + pagosHtml + '</td>' +

--- a/Blue-Cat/assets/js/empleados.js
+++ b/Blue-Cat/assets/js/empleados.js
@@ -11,7 +11,7 @@ function bd(s){return s?esc(s):'-';}
 function toast(msg,t){
   var el=document.createElement('div');
   el.className='toast toast-'+(t==='err'?'err':'ok');
-  el.innerHTML=msg;
+  BlueCatSecurity.renderToast(el,msg,t);
   document.body.appendChild(el);
   requestAnimationFrame(function(){el.classList.add('show');});
   setTimeout(function(){el.classList.remove('show');setTimeout(function(){el.remove();},300);},2500);
@@ -119,7 +119,7 @@ function showCreate(){
     '<h4 style="font-size:14px;font-weight:600;color:#1e293b;margin:12px 0 8px;border-top:1px solid #e2e8f0;padding-top:12px;"><i class="fas fa-key"></i> Credenciales de Acceso</h4>'+
     '<div class="gr2">'+
     '<div class="fld"><label>Correo acceso</label><input id="c-credc" type="email" placeholder="usuario@empresa.cl"></div>'+
-    '<div class="fld"><label>Contraseña</label><input id="c-credp" type="password" placeholder="Mínimo 6 caracteres"></div>'+
+    '<div class="fld"><label>Contraseña</label><input id="c-credp" type="password" placeholder="10+ caracteres, mayúscula, minúscula y número"></div>'+
     '</div>'+
     '<div class="mcb"><button class="btn-g" onclick="$(\'cm\').classList.remove(\'show\')">Cancelar</button><button class="btn-p" onclick="saveCreate()"><i class="fas fa-save"></i> Guardar</button></div>';
   m.classList.add('show');
@@ -1226,7 +1226,7 @@ function showCrearCredenciales(id_empleado) {
         '<h3 style="font-size:18px;font-weight:700;color:#1e293b;margin-bottom:16px;"><i class="fas fa-key" style="color:#4f46e5;"></i> Crear Credenciales</h3>' +
         '<p style="font-size:13px;color:#64748b;margin-bottom:16px;">Se generará una cuenta de acceso para este empleado.</p>' +
         '<div class="fld"><label>Correo electrónico *</label><input id="cc-correo" type="email" style="width:100%;padding:8px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:13px;" placeholder="empleado@empresa.cl"></div>' +
-        '<div class="fld"><label>Contraseña *</label><input id="cc-pass" type="password" style="width:100%;padding:8px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:13px;" placeholder="Mínimo 6 caracteres"></div>' +
+        '<div class="fld"><label>Contraseña *</label><input id="cc-pass" type="password" style="width:100%;padding:8px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:13px;" placeholder="10+ caracteres, mayúscula, minúscula y número"></div>' +
         '<div class="fld"><label>Confirmar contraseña</label><input id="cc-pass2" type="password" style="width:100%;padding:8px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:13px;"></div>' +
         '<div class="fld"><label>Rol (opcional)</label><select id="cc-rol" style="width:100%;padding:8px;border:1.5px solid #e2e8f0;border-radius:8px;font-size:13px;"><option value="">Sin rol</option>' + rolesHtml + '</select></div>' +
         '<div id="cc-feedback" style="margin:12px 0;min-height:20px;"></div>' +
@@ -1247,7 +1247,7 @@ function crearCredenciales(id_empleado) {
 
   if (!correo) { toast('Correo requerido', 'err'); return; }
   if (!pass) { toast('Contraseña requerida', 'err'); return; }
-  if (pass.length < 6) { toast('Contraseña debe tener al menos 6 caracteres', 'err'); return; }
+  if (pass.length < 10 || !/[a-z]/.test(pass) || !/[A-Z]/.test(pass) || !/\d/.test(pass)) { toast('Use 10+ caracteres, una mayúscula, una minúscula y un número', 'err'); return; }
   if (pass !== pass2) { toast('Las contraseñas no coinciden', 'err'); return; }
 
   var btn = document.querySelector('#cm .btn-p');
@@ -1278,7 +1278,7 @@ function cancelForm(id){var f=$(id);if(f)f.remove();}
 function guardarCredenciales(idEmpleado) {
   var usuario=($('ce-usuario').value||'').trim(), correo=($('ce-correo').value||'').trim(), pass=$('ce-pass').value||'';
   if(!usuario){toast('Usuario requerido','err');return;}
-  if(pass&&pass.length<6){toast('La contraseña debe tener al menos 6 caracteres','err');return;}
+  if(pass&&(pass.length<10||!/[a-z]/.test(pass)||!/[A-Z]/.test(pass)||!/\d/.test(pass))){toast('Use 10+ caracteres, una mayúscula, una minúscula y un número','err');return;}
   apiPost({accion:'editar_credenciales',id_empleado:idEmpleado,nombre:usuario,correo:correo,password:pass,activo:$('ce-activo').checked?1:0},function(){
     toast('Credenciales actualizadas');$('cm').classList.remove('show');loadEmp();
   });

--- a/Blue-Cat/assets/js/facturas.js
+++ b/Blue-Cat/assets/js/facturas.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', function() {
 function showToast(msg, type) {
   var t = document.createElement('div');
   t.className = 'toast toast-' + (type === 'error' ? 'err' : 'ok');
-  t.innerHTML = msg;
+  BlueCatSecurity.renderToast(t, msg, type);
   document.body.appendChild(t);
   requestAnimationFrame(function() { t.classList.add('show'); });
   setTimeout(function() { t.classList.remove('show'); setTimeout(function() { t.remove(); }, 300); }, 2500);
@@ -20,6 +20,7 @@ function showToast(msg, type) {
 
 /* ── Number format ── */
 function fm(n) { return '$' + Math.round(Number(n)).toLocaleString('es-CL'); }
+function esc(s) { var d = document.createElement('div'); d.textContent = String(s == null ? '' : s); return d.innerHTML; }
 
 /* ── KPIs ── */
 function loadKPIs() {
@@ -89,13 +90,13 @@ function renderTable(data, total, page, pages) {
     var tr = document.createElement('tr');
     tr.innerHTML =
       '<td>' + f.id_factura + '</td>' +
-      '<td><strong>' + (f.folio || '-') + '</strong></td>' +
-      '<td>' + (f.razon_social || f.cliente_nombre || 'Sin cliente') + '</td>' +
-      '<td>' + (f.rut || '-') + '</td>' +
+      '<td><strong>' + esc(f.folio || '-') + '</strong></td>' +
+      '<td>' + esc(f.razon_social || f.cliente_nombre || 'Sin cliente') + '</td>' +
+      '<td>' + esc(f.rut || '-') + '</td>' +
       '<td><strong>' + fm(f.total) + '</strong></td>' +
       '<td>' + fm(f.pagado) + '</td>' +
       '<td>' + fm(f.saldo) + '</td>' +
-      '<td><span class="badge ' + badgeClass + '">' + f.estado + '</span></td>' +
+      '<td><span class="badge ' + badgeClass + '">' + esc(f.estado) + '</span></td>' +
       '<td style="font-size:12px;color:#64748b;">' + (f.fecha_emision ? f.fecha_emision.substring(0,10) : '-') + '</td>' +
       '<td class="actions-cell" style="white-space:nowrap;">' +
       '<button class="btn-icon" onclick="showDetail(' + f.id_factura + ')" title="Ver detalle"><i class="fas fa-eye"></i></button>' +
@@ -138,39 +139,39 @@ function showDetail(id) {
     var itemsHtml = '';
     for (var i = 0; i < (f.detalle || []).length; i++) {
       var d = f.detalle[i];
-      itemsHtml += '<tr><td>' + d.producto + '</td><td>' + d.cantidad + '</td><td>' + fm(d.precio) + '</td><td>' + fm(d.total) + '</td></tr>';
+      itemsHtml += '<tr><td>' + esc(d.producto) + '</td><td>' + Number(d.cantidad || 0) + '</td><td>' + fm(d.precio) + '</td><td>' + fm(d.total) + '</td></tr>';
     }
     var pagosHtml = '';
     for (var j = 0; j < (f.pagos || []).length; j++) {
       var p = f.pagos[j];
-      pagosHtml += '<div class="historial-item"><span class="hi-action">' + p.metodo + '</span><span>' + fm(p.monto) + '</span><span class="hi-date">' + (p.fecha || '') + '</span></div>';
+      pagosHtml += '<div class="historial-item"><span class="hi-action">' + esc(p.metodo) + '</span><span>' + fm(p.monto) + '</span><span class="hi-date">' + esc(p.fecha || '') + '</span></div>';
     }
     var histHtml = '';
     for (var k = 0; k < (f.historial || []).length; k++) {
       var h = f.historial[k];
-      histHtml += '<div class="historial-item"><span class="hi-date">' + (h.fecha || '') + '</span><span class="hi-action">' + h.accion + '</span><span class="hi-user">' + (h.usuario || '') + '</span><span class="hi-detail">' + (h.valor_nuevo || '') + '</span></div>';
+      histHtml += '<div class="historial-item"><span class="hi-date">' + esc(h.fecha || '') + '</span><span class="hi-action">' + esc(h.accion) + '</span><span class="hi-user">' + esc(h.usuario || '') + '</span><span class="hi-detail">' + esc(h.valor_nuevo || '') + '</span></div>';
     }
 
     content.innerHTML =
       '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;">' +
-      '<h3 style="font-size:18px;font-weight:700;color:#1e293b;"><i class="fas fa-file-invoice" style="color:#4f46e5;"></i> Factura ' + f.numero + '</h3>' +
-      '<span class="badge ' + badgeClass + '" style="font-size:13px;padding:4px 14px;">' + f.estado + '</span>' +
+      '<h3 style="font-size:18px;font-weight:700;color:#1e293b;"><i class="fas fa-file-invoice" style="color:#4f46e5;"></i> Factura ' + esc(f.numero) + '</h3>' +
+      '<span class="badge ' + badgeClass + '" style="font-size:13px;padding:4px 14px;">' + esc(f.estado) + '</span>' +
       '</div>' +
       '<div class="detail-grid">' +
       '<div class="detail-section"><h4><i class="fas fa-info-circle"></i> Información General</h4>' +
-      '<div class="detail-row"><span class="dl">Folio</span><span class="dv">' + (f.folio || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Número</span><span class="dv">' + (f.numero || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Tipo</span><span class="dv">' + (f.tipo || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Emisión</span><span class="dv">' + (f.fecha_emision || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Vencimiento</span><span class="dv">' + (f.fecha_vencimiento || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Vendedor</span><span class="dv">' + (f.vendedor || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Folio</span><span class="dv">' + esc(f.folio || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Número</span><span class="dv">' + esc(f.numero || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Tipo</span><span class="dv">' + esc(f.tipo || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Emisión</span><span class="dv">' + esc(f.fecha_emision || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Vencimiento</span><span class="dv">' + esc(f.fecha_vencimiento || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Vendedor</span><span class="dv">' + esc(f.vendedor || '-') + '</span></div>' +
       '</div>' +
       '<div class="detail-section"><h4><i class="fas fa-user"></i> Cliente</h4>' +
-      '<div class="detail-row"><span class="dl">RUT</span><span class="dv">' + (f.rut || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Razón Social</span><span class="dv">' + (f.razon_social || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Dirección</span><span class="dv">' + (f.direccion || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Correo</span><span class="dv">' + (f.correo || '-') + '</span></div>' +
-      '<div class="detail-row"><span class="dl">Giro</span><span class="dv">' + (f.giro || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">RUT</span><span class="dv">' + esc(f.rut || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Razón Social</span><span class="dv">' + esc(f.razon_social || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Dirección</span><span class="dv">' + esc(f.direccion || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Correo</span><span class="dv">' + esc(f.correo || '-') + '</span></div>' +
+      '<div class="detail-row"><span class="dl">Giro</span><span class="dv">' + esc(f.giro || '-') + '</span></div>' +
       '</div>' +
       '</div>' +
       '<h4 style="margin-top:14px;font-size:13px;font-weight:600;color:#1e293b;"><i class="fas fa-box"></i> Productos</h4>' +

--- a/Blue-Cat/assets/js/inventario.js
+++ b/Blue-Cat/assets/js/inventario.js
@@ -25,7 +25,7 @@ function api(accion, data, cb) {
 function toast(msg, type) {
   var t = document.createElement('div');
   t.className = 'toast toast-' + (type === 'error' ? 'err' : 'ok');
-  t.innerHTML = '<i class="fas fa-' + (type === 'error' ? 'exclamation-circle' : 'check-circle') + '"></i> ' + msg;
+  BlueCatSecurity.renderToast(t, msg, type);
   document.body.appendChild(t);
   requestAnimationFrame(function() { t.classList.add('show'); });
   setTimeout(function() { t.classList.remove('show'); setTimeout(function() { t.remove(); }, 300); }, 2500);

--- a/Blue-Cat/assets/js/login_pvt.js
+++ b/Blue-Cat/assets/js/login_pvt.js
@@ -136,7 +136,7 @@ function CloseSesionPopUp() {
 function showToast(msg, type) {
   var t = document.createElement('div');
   t.className = 'toast toast-' + (type === 'error' ? 'err' : 'ok');
-  t.innerHTML = msg;
+  BlueCatSecurity.renderToast(t, msg, type);
   document.body.appendChild(t);
   requestAnimationFrame(function() { t.classList.add('show'); });
   setTimeout(function() { t.classList.remove('show'); setTimeout(function() { t.remove(); }, 300); }, 2500);

--- a/Blue-Cat/assets/js/navbar.js
+++ b/Blue-Cat/assets/js/navbar.js
@@ -137,6 +137,11 @@
       if (!response.ok) throw new Error('HTTP ' + response.status);
       return response.json();
     }).then(function (data) {
+      window.BlueCatPermissions = data.permisos || {};
+      window.blueCatHasPermission = function (modulo, accion) {
+        return !!(window.BlueCatPermissions[modulo] && window.BlueCatPermissions[modulo].indexOf(accion) !== -1);
+      };
+      document.dispatchEvent(new CustomEvent('bluecat:permissions-ready', { detail: window.BlueCatPermissions }));
       render(data.modulos || []);
     }).catch(function () {
       render([{ codigo: 'inicio', nombre: 'Inicio', icono: 'fa-home', ruta: 'Inicio.html' }]);

--- a/Blue-Cat/assets/js/proveedores.js
+++ b/Blue-Cat/assets/js/proveedores.js
@@ -9,7 +9,7 @@ function esc(s) { if(!s)return''; var d=document.createElement('div'); d.appendC
 function toast(msg, t) {
   var el = document.createElement('div');
   el.className = 'toast toast-' + (t==='err'?'err':'ok');
-  el.innerHTML = msg;
+  BlueCatSecurity.renderToast(el, msg, t);
   document.body.appendChild(el);
   requestAnimationFrame(function() { el.classList.add('show'); });
   setTimeout(function() { el.classList.remove('show'); setTimeout(function() { el.remove(); },300); }, 2500);

--- a/Blue-Cat/assets/js/security.js
+++ b/Blue-Cat/assets/js/security.js
@@ -1,0 +1,56 @@
+(function () {
+  'use strict';
+  function csrfToken() {
+    var match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+  function isUnsafe(method) {
+    return !['GET', 'HEAD', 'OPTIONS'].includes(String(method || 'GET').toUpperCase());
+  }
+  function plainMessage(value) {
+    return String(value == null ? '' : value)
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+  function renderToast(element, message, type) {
+    while (element.firstChild) element.removeChild(element.firstChild);
+    var icon = document.createElement('i');
+    icon.className = 'fas fa-' + ((type === 'error' || type === 'err') ? 'exclamation-circle' : 'check-circle');
+    icon.setAttribute('aria-hidden', 'true');
+    element.appendChild(icon);
+    element.appendChild(document.createTextNode(' ' + plainMessage(message)));
+  }
+  window.BlueCatSecurity = Object.freeze({
+    plainMessage: plainMessage,
+    renderToast: renderToast
+  });
+  var nativeFetch = window.fetch;
+  window.fetch = function (input, init) {
+    init = init || {};
+    var method = init.method || (input && input.method) || 'GET';
+    if (isUnsafe(method)) {
+      var headers = new Headers(init.headers || (input && input.headers) || {});
+      headers.set('X-Requested-With', 'XMLHttpRequest');
+      var token = csrfToken();
+      if (token) headers.set('X-CSRF-Token', token);
+      init.headers = headers;
+    }
+    init.credentials = init.credentials || 'same-origin';
+    return nativeFetch.call(this, input, init);
+  };
+  var nativeOpen = XMLHttpRequest.prototype.open;
+  var nativeSend = XMLHttpRequest.prototype.send;
+  XMLHttpRequest.prototype.open = function (method) {
+    this.__bluecatUnsafe = isUnsafe(method);
+    return nativeOpen.apply(this, arguments);
+  };
+  XMLHttpRequest.prototype.send = function () {
+    if (this.__bluecatUnsafe) {
+      this.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+      var token = csrfToken();
+      if (token) this.setRequestHeader('X-CSRF-Token', token);
+    }
+    return nativeSend.apply(this, arguments);
+  };
+})();

--- a/Blue-Cat/assets/js/ventas.js
+++ b/Blue-Cat/assets/js/ventas.js
@@ -67,7 +67,7 @@ function apiVentasPost(accion, data, cb) {
 function toast(msg, type) {
   var t = document.createElement('div');
   t.className = 'toast toast-' + (type === 'err' ? 'err' : 'ok');
-  t.innerHTML = msg;
+  BlueCatSecurity.renderToast(t, msg, type);
   document.body.appendChild(t);
   requestAnimationFrame(function () { t.classList.add('show'); });
   setTimeout(function () { t.classList.remove('show'); setTimeout(function () { t.remove(); }, 300); }, 2500);

--- a/Blue-Cat/database/migrations/020_security_foundation.sql
+++ b/Blue-Cat/database/migrations/020_security_foundation.sql
@@ -1,0 +1,62 @@
+-- Phase 3: authentication, sessions and request security foundation.
+SET NAMES utf8mb4;
+START TRANSACTION;
+
+ALTER TABLE usuario
+  ADD COLUMN bloqueado_hasta DATETIME NULL AFTER intentos_fallidos,
+  ADD COLUMN ultimo_fallo_login DATETIME NULL AFTER bloqueado_hasta,
+  ADD COLUMN password_changed_at DATETIME NULL AFTER ultimo_acceso,
+  ADD COLUMN requiere_cambio_password TINYINT(1) NOT NULL DEFAULT 0 AFTER password_changed_at,
+  ADD COLUMN session_version INT NOT NULL DEFAULT 1 AFTER requiere_cambio_password,
+  ADD KEY idx_usuario_bloqueo (bloqueado_hasta),
+  ADD KEY idx_usuario_cuenta_activo_sesion (id_cuenta, activo, session_version);
+
+CREATE TABLE auth_intento (
+  id_intento BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  identity_hash CHAR(64) NOT NULL,
+  ip_hash CHAR(64) NOT NULL,
+  resultado ENUM('FALLO','EXITO','BLOQUEADO') NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id_intento),
+  KEY idx_auth_intento_identity_fecha (identity_hash, created_at),
+  KEY idx_auth_intento_ip_fecha (ip_hash, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE core_sesion (
+  id_sesion BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  id_cuenta INT NOT NULL,
+  id_user INT NOT NULL,
+  session_hash CHAR(64) NOT NULL,
+  session_version INT NOT NULL,
+  ip_hash CHAR(64) NULL,
+  user_agent_hash CHAR(64) NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_activity_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at DATETIME NOT NULL,
+  revoked_at DATETIME NULL,
+  revoked_by INT NULL,
+  revoke_reason VARCHAR(180) NULL,
+  PRIMARY KEY (id_sesion),
+  UNIQUE KEY uq_core_sesion_hash (session_hash),
+  KEY idx_core_sesion_user_active (id_user, revoked_at, expires_at),
+  KEY idx_core_sesion_account_active (id_cuenta, revoked_at, expires_at),
+  CONSTRAINT fk_core_sesion_cuenta FOREIGN KEY (id_cuenta) REFERENCES cuenta(id_cuenta) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_core_sesion_user FOREIGN KEY (id_user) REFERENCES usuario(id_user) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_core_sesion_revoker FOREIGN KEY (revoked_by) REFERENCES usuario(id_user) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO permiso (modulo,accion,descripcion) VALUES
+('seguridad','ver_sesiones','Ver sesiones activas de la cuenta'),
+('seguridad','revocar_sesiones','Revocar sesiones de usuarios de la cuenta'),
+('seguridad','ver_auditoria','Ver la auditoria de seguridad'),
+('usuarios','restablecer_password','Restablecer credenciales de empleados')
+ON DUPLICATE KEY UPDATE descripcion=VALUES(descripcion);
+
+INSERT IGNORE INTO rol_permiso (id_rol,id_permiso)
+SELECT r.id_rol,p.id_permiso
+FROM rol r
+JOIN permiso p ON (p.modulo='seguridad' AND p.accion IN ('ver_sesiones','revocar_sesiones','ver_auditoria'))
+                 OR (p.modulo='usuarios' AND p.accion='restablecer_password')
+WHERE r.nombre='Administrador' AND r.activo=1;
+
+COMMIT;

--- a/Blue-Cat/database/migrations/021_pos_action_permissions.sql
+++ b/Blue-Cat/database/migrations/021_pos_action_permissions.sql
@@ -1,0 +1,14 @@
+-- Phase 3: explicit permission for associating an existing customer in POS.
+SET NAMES utf8mb4;
+START TRANSACTION;
+
+INSERT INTO permiso(modulo,accion,descripcion) VALUES
+('pos','asociar_cliente','Buscar y asociar clientes existentes a una venta POS')
+ON DUPLICATE KEY UPDATE descripcion=VALUES(descripcion);
+
+INSERT IGNORE INTO rol_permiso(id_rol,id_permiso)
+SELECT r.id_rol,p.id_permiso
+FROM rol r JOIN permiso p ON p.modulo='pos' AND p.accion='asociar_cliente'
+WHERE r.activo=1 AND r.nombre IN ('Administrador','Supervisor','Cajero','Vendedor');
+
+COMMIT;

--- a/Blue-Cat/docs/security/permission-matrix.md
+++ b/Blue-Cat/docs/security/permission-matrix.md
@@ -1,0 +1,51 @@
+# Matriz canónica de autorización
+
+Esta matriz define la política Beta. La interfaz solo refleja permisos; la decisión final siempre ocurre en la API mediante `requireUser()`, `requirePermission()` o una autorización puntual de supervisor.
+
+## Alcances
+
+- **Propio:** registros creados por el empleado o asociados a su sesión/caja.
+- **Cuenta:** datos compartidos por propietario y empleados de la misma cuenta SaaS.
+- **Sucursal:** reservado para la etapa multi-sucursal; nunca amplía el acceso a otra cuenta.
+- **Puntual:** una sola operación, contexto y plazo, aprobada por PIN/tarjeta de Supervisor.
+
+## Roles base
+
+| Capacidad | Administrador | Supervisor | Cajero | Bodeguero | Vendedor |
+|---|---:|---:|---:|---:|---:|
+| POS y venta | Cuenta | Cuenta | Propio | No | Propio |
+| Ver ventas | Cuenta | Cuenta | Propio | No | Propio |
+| Anular/devolver | Directo | Directo | Puntual | No | Puntual |
+| Abrir/cerrar caja | Cuenta | Cuenta | Propio | No | Propio |
+| Inventario operativo | Cuenta | Cuenta | No | Cuenta | No |
+| Ajustes sensibles | Directo | Directo | No | Puntual | No |
+| Clientes | Cuenta | Cuenta | Según permiso | No | Cuenta |
+| Empleados | Cuenta | Lectura según permiso | No | No | No |
+| Roles y permisos | Cuenta | No, salvo asignación explícita | No | No | No |
+| Sesiones y auditoría | Cuenta | No, salvo asignación explícita | No | No | No |
+
+Los roles son plantillas provisionadas dentro de cada cuenta. Un empleado nunca es un tenant separado: productos, stock, clientes y ventas pertenecen a la cuenta y se filtran adicionalmente por alcance cuando corresponde.
+
+## Rutas sensibles
+
+| Endpoint / acción | Permiso base | Permiso específico / alcance |
+|---|---|---|
+| `pos.php` GET/POST | `pos.ver` | La acción exige además abrir/cerrar/realizar venta o política puntual de Supervisor |
+| `ventas.php` lectura | `ventas.ver` | Propio; `ventas.ver_todos` amplía solo a la misma cuenta |
+| `inventario.php` | `inventario.ver` | Crear, editar, eliminar, importar, exportar, movimientos y transferencias son independientes |
+| `core.php` roles | `configuracion.ver` | `configuracion.gestionar_roles` |
+| `core.php` usuarios | `configuracion.ver` | `configuracion.gestionar_usuarios` |
+| cambio de contraseña | autenticado | `usuarios.restablecer_password`, revoca sesiones del afectado |
+| sesiones activas | autenticado | `seguridad.ver_sesiones`, alcance cuenta |
+| revocar sesión | autenticado | `seguridad.revocar_sesiones`, alcance cuenta |
+| auditoría | autenticado | `seguridad.ver_auditoria`, alcance cuenta |
+| exportación de facturas | autenticado | `facturas.exportar`, alcance cuenta |
+
+## Invariantes comprobables
+
+1. Ocultar o mostrar un botón nunca concede acceso.
+2. Un identificador de otra cuenta se responde como recurso inexistente o no autorizado.
+3. `ventas.ver_todos` no permite cruzar cuentas.
+4. El token de Supervisor es de un solo uso, dura 90 segundos y está ligado a acción y contexto.
+5. Cambiar contraseña, desactivar credenciales o eliminar un empleado revoca sus sesiones activas.
+6. Toda petición de escritura requiere defensa CSRF y una sesión vigente registrada por dispositivo.

--- a/Blue-Cat/docs/security/threat-model.md
+++ b/Blue-Cat/docs/security/threat-model.md
@@ -1,0 +1,33 @@
+# Modelo de amenazas Beta
+
+## Activos y límites de confianza
+
+Los activos prioritarios son ventas, caja, stock, credenciales, permisos, datos de clientes, auditoría y respaldos. El navegador del POS, incluso dentro de la LAN, no es confiable. La API es el límite de autorización; MySQL y el proceso local de Blue-Cat forman el núcleo confiable. Cada `cuenta` es un tenant y ningún rol puede ampliar acceso a otra cuenta.
+
+## Amenazas principales y controles
+
+| Amenaza | Ejemplo | Control Beta | Evidencia |
+|---|---|---|---|
+| Suplantación | contraseña robada o fuerza bruta | bcrypt, política mínima, bloqueo progresivo, respuesta genérica, sesión regenerada | `test-security-foundation.php` |
+| Secuestro/reutilización de sesión | cookie copiada o empleado desactivado | cookie HttpOnly/SameSite, registro por dispositivo, caducidad por inactividad, versión y revocación | prueba de login/logout/revocación |
+| CSRF | sitio externo intenta cerrar caja | token/cabecera de misma procedencia y SameSite | POST sin defensa devuelve `CSRF_REJECTED` |
+| Elevación de privilegio | mostrar un botón oculto o llamar la API manualmente | `requirePermission()` y políticas específicas en servidor | `configuracion.ver` no permite gestionar roles |
+| IDOR / cruce de tenant | cambiar un `id_pedido` por el de otra cuenta | `TenantContext`, filtros `id_cuenta` y validadores de entidad | pruebas de aislamiento existentes |
+| Abuso de Supervisor | reutilizar PIN o aprobación | credencial hasheada, token opaco de un uso, 90 s, acción y contexto exactos | `test-supervisor-authorization.php` |
+| Archivo malicioso | renombrar un ejecutable a `.xls` | tamaño, extensión, MIME, carga HTTP real, máximo de filas/celdas y parseo sin red | importador de inventario |
+| XSS / clickjacking | dato de cliente insertado en HTML | escape en render, CSP, `nosniff`, `frame-ancestors` y `X-Frame-Options` | cabeceras Apache/API |
+| Exposición de secretos/backups | navegar a `.env` o `storage/backups` | reglas Apache, sin listado de directorios | petición de respaldo devuelve 403 |
+| Repudio | negar una anulación o cambio de rol | auditoría con usuario, cuenta, IP/contexto y fecha; fallos de telemetría no rompen caja | tablas de auditoría |
+
+## Riesgos residuales coordinados con las fases siguientes
+
+1. El mecanismo `FORCE_HTTPS` y HSTS ya existe; la emisión e instalación de certificados confiables se integra en el instalador de la Fase 4 según `tls-local.md`.
+2. `APP_KEY` ya se genera de forma única y atómica; una rotación controlada de claves queda como mantenimiento posterior porque invalida hashes de sesiones y rate limiting.
+3. Los mensajes no confiables de las API ya se renderizan como texto y los datos de factura/configuración revisados se escapan; CI bloquea la reintroducción del patrón inseguro de toast. La eliminación total de HTML construido dinámicamente es una refactorización progresiva.
+4. El baseline estático ya corre en CI. Un DAST autenticado y un SAST de terceros se incorporarán cuando el entorno piloto sea reproducible.
+5. La recuperación actual es administrativa, exige permiso y revoca sesiones. El autoservicio con token temporal queda fuera del alcance Beta local-first.
+6. La retención, exportación firmada y protección criptográfica de auditoría se definirá junto con backups y operación en Fase 7.
+
+## Criterio de salida
+
+La Fase 3 solo se cierra cuando las pruebas negativas demuestran que una sesión vencida, una petición sin CSRF, un usuario sin permiso, un identificador de otro tenant y un token de Supervisor reutilizado son rechazados por el backend, independientemente de la interfaz.

--- a/Blue-Cat/docs/security/tls-local.md
+++ b/Blue-Cat/docs/security/tls-local.md
@@ -1,0 +1,22 @@
+# TLS para Blue-Cat Server en la red local
+
+Blue-Cat permite desarrollo por HTTP, pero el instalador de servidor debe publicar la aplicación por HTTPS y configurar `FORCE_HTTPS=true`. Con esa opción, la API rechaza HTTP con `426 HTTPS_REQUIRED`; las cookies se marcan `Secure` y las respuestas HTTPS incluyen HSTS.
+
+## Diseño para el instalador
+
+1. Crear una autoridad certificadora local exclusiva de la instalación y guardar su clave privada fuera del directorio web con permisos del servicio.
+2. Emitir un certificado de servidor con SAN para el nombre estable del equipo y sus direcciones LAN previstas. No depender de `localhost` para otros POS.
+3. Instalar únicamente el certificado raíz público en el almacén de confianza de cada dispositivo cliente mediante el asistente de conexión.
+4. Configurar el servidor web para TLS 1.2 o superior, iniciar por HTTPS y redirigir la navegación estática desde HTTP.
+5. Activar `FORCE_HTTPS=true` solo después de verificar el certificado para evitar bloquear la instalación a mitad del proceso.
+6. Renovar el certificado antes de vencer sin reemplazar innecesariamente la CA; registrar emisión, renovación y revocación.
+
+La CA privada nunca se copia a los POS cliente. Un cliente nuevo recibe la CA pública mediante un proceso administrativo confirmado en el servidor, no desde una página HTTP sin autenticar.
+
+## Verificación de aceptación
+
+- Un navegador cliente abre el nombre LAN sin advertencias de certificado.
+- Una llamada directa por HTTP a la API devuelve `426` o es redirigida antes de llegar a PHP.
+- La cookie `BLUECATSESSID` incluye `Secure`, `HttpOnly` y `SameSite=Lax`.
+- La respuesta HTTPS incluye CSP, `nosniff`, protección de frame y HSTS.
+- Revocar la confianza del dispositivo impide su reconexión hasta autorizarlo otra vez.

--- a/Blue-Cat/index.html
+++ b/Blue-Cat/index.html
@@ -191,6 +191,7 @@
     </div>
   </div>
 
-  <script src="assets/js/Index.js?v=5"></script>
+  <script src="assets/js/security.js?v=1"></script>
+  <script src="assets/js/Index.js?v=6"></script>
 </body>
 </html>

--- a/Blue-Cat/public/Inicio.html
+++ b/Blue-Cat/public/Inicio.html
@@ -148,6 +148,7 @@
     </div>
   </div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>
   <script src="../assets/js/navbar.js?v=3"></script>
 </body>

--- a/Blue-Cat/public/configuracion.html
+++ b/Blue-Cat/public/configuracion.html
@@ -245,6 +245,7 @@
   <div class="popup" id="cfg-modal"><div class="popup-content" style="max-width:600px;"><span class="close-btn" onclick="closeCfgModal()">&times;</span><div id="cfg-modal-body"></div></div></div>
   <div id="cerrar-sesion-popup" class="popup"><div class="popup-content"><span class="close-btn" onclick="CloseSesionPopUp()">&times;</span><h2><i class="fas fa-sign-out-alt"></i> Cerrar Sesión</h2><p>¿Está seguro de que desea cerrar sesión?</p><button class="btn btn-danger" onclick="cerrarSesion()" style="width:100%;justify-content:center;">Cerrar Sesión</button></div></div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/configuracion.js?v=3"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>
   <script src="../assets/js/navbar.js?v=3"></script>

--- a/Blue-Cat/public/crm.html
+++ b/Blue-Cat/public/crm.html
@@ -211,6 +211,7 @@
     </div>
   </div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/crm.js"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>
   <script src="../assets/js/navbar.js?v=3"></script>

--- a/Blue-Cat/public/cuadre_de_ventas.html
+++ b/Blue-Cat/public/cuadre_de_ventas.html
@@ -493,6 +493,7 @@
     </div>
   </div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/supervisor-approval.js?v=1"></script>
   <script src="../assets/js/cuadre_de_ventas.js?v=7"></script>
   <script src="../assets/js/navbar.js?v=3"></script>

--- a/Blue-Cat/public/empleados.html
+++ b/Blue-Cat/public/empleados.html
@@ -129,6 +129,7 @@
     <button class="btn btn-danger" onclick="cerrarSesion()" style="width:100%;justify-content:center;">Cerrar Sesión</button>
   </div></div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/empleados.js?v=14"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>
   <script src="../assets/js/navbar.js?v=3"></script>

--- a/Blue-Cat/public/facturas.html
+++ b/Blue-Cat/public/facturas.html
@@ -121,6 +121,7 @@
     <button class="btn btn-danger" onclick="cerrarSesion()" style="width:100%;justify-content:center;">Cerrar Sesión</button>
   </div></div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="../assets/js/facturas.js?v=5"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>

--- a/Blue-Cat/public/inventario.html
+++ b/Blue-Cat/public/inventario.html
@@ -286,6 +286,7 @@
     </div>
   </div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/supervisor-approval.js?v=1"></script>
   <script src="../assets/js/inventario.js?v=6"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>

--- a/Blue-Cat/public/pos.html
+++ b/Blue-Cat/public/pos.html
@@ -116,6 +116,7 @@
     <button class="btn btn-danger" onclick="cerrarSesion()" style="width:100%;justify-content:center;">Cerrar Sesión</button>
   </div></div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/supervisor-approval.js?v=1"></script>
   <script src="../assets/js/pos.js?v=10"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>

--- a/Blue-Cat/public/proveedores.html
+++ b/Blue-Cat/public/proveedores.html
@@ -126,6 +126,7 @@
     <button class="btn btn-danger" onclick="cerrarSesion()" style="width:100%;justify-content:center;">Cerrar Sesión</button>
   </div></div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/proveedores.js"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>
   <script src="../assets/js/navbar.js?v=3"></script>

--- a/Blue-Cat/public/ventas.html
+++ b/Blue-Cat/public/ventas.html
@@ -347,6 +347,7 @@
     </div>
   </div>
 
+  <script src="../assets/js/security.js?v=1"></script>
   <script src="../assets/js/ventas.js"></script>
   <script src="../assets/js/login_pvt.js?v=5"></script>
   <script src="../assets/js/navbar.js?v=3"></script>

--- a/Blue-Cat/scripts/ensure-app-key.php
+++ b/Blue-Cat/scripts/ensure-app-key.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$envPath = $root . DIRECTORY_SEPARATOR . '.env';
+foreach (array_slice($argv, 1) as $arg) {
+    if (str_starts_with($arg, '--env=')) {
+        $candidate = substr($arg, 6);
+        $envPath = str_starts_with($candidate, DIRECTORY_SEPARATOR) || preg_match('/^[A-Za-z]:[\\\\\/]/', $candidate)
+            ? $candidate
+            : $root . DIRECTORY_SEPARATOR . $candidate;
+    }
+}
+
+if (!is_file($envPath)) {
+    fwrite(STDERR, "No existe el archivo de entorno: {$envPath}\n");
+    exit(1);
+}
+if (!is_readable($envPath) || !is_writable($envPath)) {
+    fwrite(STDERR, "El archivo de entorno no permite lectura y escritura.\n");
+    exit(1);
+}
+
+$contents = file_get_contents($envPath);
+if ($contents === false) {
+    fwrite(STDERR, "No fue posible leer el archivo de entorno.\n");
+    exit(1);
+}
+if (preg_match('/^APP_KEY=(.+)$/m', $contents, $match) && trim($match[1], " \t\r\n\"'") !== '') {
+    fwrite(STDOUT, "APP_KEY ya está configurada; no se realizaron cambios.\n");
+    exit(0);
+}
+
+$key = 'base64:' . base64_encode(random_bytes(32));
+if (preg_match('/^APP_KEY=.*$/m', $contents)) {
+    $updated = preg_replace('/^APP_KEY=.*$/m', 'APP_KEY=' . $key, $contents, 1);
+} else {
+    $updated = rtrim($contents) . PHP_EOL . 'APP_KEY=' . $key . PHP_EOL;
+}
+if (!is_string($updated)) {
+    fwrite(STDERR, "No fue posible preparar APP_KEY.\n");
+    exit(1);
+}
+
+$temp = $envPath . '.tmp.' . bin2hex(random_bytes(6));
+if (file_put_contents($temp, $updated, LOCK_EX) === false || !rename($temp, $envPath)) {
+    @unlink($temp);
+    fwrite(STDERR, "No fue posible guardar APP_KEY de forma atómica.\n");
+    exit(1);
+}
+fwrite(STDOUT, "APP_KEY única generada correctamente.\n");

--- a/Blue-Cat/scripts/invoke-api-test.php
+++ b/Blue-Cat/scripts/invoke-api-test.php
@@ -15,6 +15,8 @@ $userId = (int)(cliOption('--user') ?? 0);
 if (!$env || !preg_match('/^[a-z0-9_-]+\.php$/i',$endpoint) || $userId <= 0) exit(2);
 $envPath = preg_match('/^(?:[A-Za-z]:[\\\\\/]|\/)/',$env) ? $env : $root.'/'.$env;
 putenv('BLUECAT_ENV_FILE='.$envPath);
+putenv('BLUECAT_TEST_SESSION=1');
+$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
 require_once $root.'/assets/api/_db.php';
 if (getenv('APP_ENV') !== 'test' || DB_NAME === 'erp') exit(3);
 

--- a/Blue-Cat/scripts/test-promotion-engine.php
+++ b/Blue-Cat/scripts/test-promotion-engine.php
@@ -20,11 +20,11 @@ $evaluate=function(int $promotion,string $code,array $items,?int $client=null)us
 $db->begin_transaction();
 try{
     $db->query("INSERT INTO cuenta(nombre,estado) VALUES('Promotion Engine Test','ACTIVA')");$account=(int)$db->insert_id;
-    $hash=password_hash('Promotion-Test-2026',PASSWORD_DEFAULT);$stmt=$db->prepare("INSERT INTO usuario(id_cuenta,nombre,correo,password,activo) VALUES(?,'promo-test','promo-test@local',?,1)");$stmt->bind_param('is',$account,$hash);$stmt->execute();$user=(int)$db->insert_id;$stmt->close();
+    $hash=password_hash('Promotion-Test-2026',PASSWORD_DEFAULT);$stmt=$db->prepare("INSERT INTO usuario(id_cuenta,nombre,correo,password,activo,validar_sesion) VALUES(?,'promo-test','promo-test@local',?,1,0)");$stmt->bind_param('is',$account,$hash);$stmt->execute();$user=(int)$db->insert_id;$stmt->close();
     $stmt=$db->prepare("INSERT INTO producto(id_user,id_cuenta,nombre_producto,precio_venta,codigo_de_barras,sku,activo) VALUES(?,?,?, ?,?,?,1)");
     $name='Producto A';$price=1000;$barcode='PROMO-A';$sku='SKU-A';$stmt->bind_param('iisiss',$user,$account,$name,$price,$barcode,$sku);$stmt->execute();$productA=(int)$db->insert_id;
     $name='Producto B';$price=2000;$barcode='PROMO-B';$sku='SKU-B';$stmt->bind_param('iisiss',$user,$account,$name,$price,$barcode,$sku);$stmt->execute();$productB=(int)$db->insert_id;$stmt->close();
-    $stmt=$db->prepare("INSERT INTO cliente(id_user,id_cuenta,codigo,nombre,categoria,clasificacion,lista_precios,activo) VALUES(?,?,'PROMO-CLIENT','Cliente VIP','VIP','VIP','MAYORISTA',1)");$stmt->bind_param('ii',$user,$account);$stmt->execute();$client=(int)$db->insert_id;$stmt->close();
+    $stmt=$db->prepare("INSERT INTO cliente(id_user,id_cuenta,codigo,nombre,razon_social,categoria,clasificacion,lista_precios,activo) VALUES(?,?,'PROMO-CLIENT','Cliente VIP','Cliente VIP','VIP','VIP','MAYORISTA',1)");$stmt->bind_param('ii',$user,$account);$stmt->execute();$client=(int)$db->insert_id;$stmt->close();
 
     $p=$insertPromotion('T-2X1','2X1',0,2,['cantidad_pagada'=>1]);$scope($p,$productA);
     [$one,$app]=$evaluate($p,'T-2X1',[['id_producto'=>$productA,'cantidad'=>1]]);$assert($app===null,'2x1 no beneficia una unidad');
@@ -44,5 +44,5 @@ try{
     [$r,$app]=$evaluate($p,'T-SEGMENT',[['id_producto'=>$productA,'cantidad'=>1]],null);$assert($app===null,'segmentación rechaza consumidor no autorizado');
 
     $db->rollback();
-}catch(Throwable $e){$db->rollback();fwrite(STDERR,'FAIL '.$e->getMessage()."\n");exit(1);}
+}catch(Throwable $e){$db->rollback();fwrite(STDERR,'FAIL '.$e->getMessage().' at line '.$e->getLine()."\n");exit(1);}
 exit($failures?1:0);

--- a/Blue-Cat/scripts/test-security-foundation.php
+++ b/Blue-Cat/scripts/test-security-foundation.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+function securityTestOption(string $name): ?string {
+    foreach (array_slice($_SERVER['argv'], 1) as $argument) {
+        if (str_starts_with($argument, $name.'=')) return substr($argument, strlen($name) + 1);
+    }
+    return null;
+}
+
+function securityTestAssert(bool $condition, string $message): void {
+    if (!$condition) throw new RuntimeException($message);
+    echo "PASS {$message}\n";
+}
+
+function securityTestRequest(string $url, string $method, ?array $form, string $cookieFile, bool $ajax = false, bool $json = false): array {
+    $curl = curl_init($url);
+    $headers = $ajax ? ['X-Requested-With: XMLHttpRequest'] : [];
+    if ($json) $headers[] = 'Content-Type: application/json';
+    curl_setopt_array($curl, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_CUSTOMREQUEST => $method,
+        CURLOPT_HTTPHEADER => $headers,
+        CURLOPT_COOKIEJAR => $cookieFile,
+        CURLOPT_COOKIEFILE => $cookieFile,
+        CURLOPT_FOLLOWLOCATION => false,
+        CURLOPT_TIMEOUT => 10,
+    ]);
+    if ($form !== null) curl_setopt($curl, CURLOPT_POSTFIELDS, $json ? json_encode($form) : http_build_query($form));
+    $body = (string)curl_exec($curl);
+    if ($body === '' && curl_errno($curl)) throw new RuntimeException(curl_error($curl));
+    $status = (int)curl_getinfo($curl, CURLINFO_RESPONSE_CODE);
+    curl_close($curl);
+    return [$status, json_decode($body, true), $body];
+}
+
+$root = dirname(__DIR__);
+$envFile = securityTestOption('--env') ?? $root.'/.env';
+if (!preg_match('/^(?:[A-Za-z]:[\\\\\/]|\/)/', $envFile)) $envFile = $root.'/'.$envFile;
+foreach (file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+    $line = trim($line);
+    if ($line === '' || str_starts_with($line, '#') || !str_contains($line, '=')) continue;
+    [$key,$value] = array_map('trim', explode('=', $line, 2));
+    $_ENV[$key] = trim($value, "\"'");
+}
+if (($_ENV['APP_ENV'] ?? '') !== 'test' && !in_array('--allow-production', $_SERVER['argv'], true)) {
+    throw new RuntimeException('Use APP_ENV=test o confirme una prueba transitoria con --allow-production.');
+}
+
+$db = new mysqli($_ENV['DB_HOST'] ?? 'localhost', $_ENV['DB_USER'] ?? '', $_ENV['DB_PASSWORD'] ?? '', $_ENV['DB_NAME'] ?? '', (int)($_ENV['DB_PORT'] ?? 3306));
+$db->set_charset('utf8mb4');
+$base = rtrim(securityTestOption('--base-url') ?? 'http://localhost/Blue-Cat/assets/api', '/');
+$suffix = bin2hex(random_bytes(6));
+$username = 'st-'.$suffix;
+$email = $username.'@local.test';
+$password = 'Security-Test-2026';
+$cookieFile = tempnam(sys_get_temp_dir(), 'bluecat-security-');
+$accountId = 0;
+$userId = 0;
+$roleId = 0;
+
+try {
+    $stmt = $db->prepare("INSERT INTO cuenta(nombre,estado) VALUES (?,'ACTIVA')");
+    $stmt->bind_param('s', $username); $stmt->execute(); $accountId=(int)$db->insert_id; $stmt->close();
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    $stmt = $db->prepare('INSERT INTO usuario(id_cuenta,nombre,correo,password,activo,validar_sesion,password_changed_at) VALUES (?,?,?,?,1,0,NOW())');
+    $stmt->bind_param('isss', $accountId, $username, $email, $hash); $stmt->execute(); $userId=(int)$db->insert_id; $stmt->close();
+    $stmt = $db->prepare('UPDATE cuenta SET id_usuario_propietario=? WHERE id_cuenta=?');
+    $stmt->bind_param('ii', $userId, $accountId); $stmt->execute(); $stmt->close();
+    $roleName='Security test role';
+    $stmt=$db->prepare('INSERT INTO rol(id_cuenta,nombre,descripcion,activo,es_sistema,es_plantilla) VALUES (?,?,?,1,0,0)');
+    $stmt->bind_param('iss',$accountId,$roleName,$roleName);$stmt->execute();$roleId=(int)$db->insert_id;$stmt->close();
+    $stmt=$db->prepare("INSERT INTO rol_permiso(id_rol,id_permiso) SELECT ?,id_permiso FROM permiso WHERE modulo='configuracion' AND accion='ver'");
+    $stmt->bind_param('i',$roleId);$stmt->execute();$stmt->close();
+    $stmt=$db->prepare('INSERT INTO usuario_rol(id_user,id_rol) VALUES (?,?)');$stmt->bind_param('ii',$userId,$roleId);$stmt->execute();$stmt->close();
+
+    [$status,,$body] = securityTestRequest($base.'/auth.php?accion=login', 'POST', ['username'=>$username,'password'=>$password], $cookieFile, false);
+    securityTestAssert($status === 403 && str_contains($body, 'CSRF_REJECTED'), "CSRF rechaza POST sin cabecera ni token (HTTP {$status}: {$body})");
+
+    $maxAttempts = max(3, (int)($_ENV['LOGIN_MAX_ATTEMPTS'] ?? 5));
+    for ($attempt=1; $attempt<=$maxAttempts; $attempt++) {
+        [$status] = securityTestRequest($base.'/auth.php?accion=login', 'POST', ['username'=>$username,'password'=>'Incorrect-'.$attempt], $cookieFile, true);
+        securityTestAssert($status === 401, "intento inválido {$attempt} usa respuesta genérica");
+    }
+    [$status] = securityTestRequest($base.'/auth.php?accion=login', 'POST', ['username'=>$username,'password'=>$password], $cookieFile, true);
+    securityTestAssert($status === 429, 'bloqueo progresivo impide login aun con clave correcta');
+    $stmt=$db->prepare('UPDATE usuario SET intentos_fallidos=0,bloqueado_hasta=NULL,ultimo_fallo_login=NULL WHERE id_user=?');
+    $stmt->bind_param('i',$userId);$stmt->execute();$stmt->close();
+
+    [$status,$login] = securityTestRequest($base.'/auth.php?accion=login', 'POST', ['username'=>$username,'password'=>$password], $cookieFile, true);
+    securityTestAssert($status === 200 && !empty($login['ok']), 'login válido crea una sesión autenticada');
+    $stmt=$db->prepare('SELECT COUNT(*) total FROM core_sesion WHERE id_user=? AND revoked_at IS NULL AND expires_at>NOW()');
+    $stmt->bind_param('i',$userId);$stmt->execute();$active=(int)$stmt->get_result()->fetch_assoc()['total'];$stmt->close();
+    securityTestAssert($active === 1, 'sesión activa se registra por dispositivo');
+
+    [$status,$state] = securityTestRequest($base.'/auth.php?accion=estado', 'GET', null, $cookieFile);
+    securityTestAssert($status === 200 && !empty($state['ok']), 'sesión registrada permite continuar');
+    [$status] = securityTestRequest($base.'/pos.php?accion=productos', 'GET', null, $cookieFile);
+    securityTestAssert($status === 403, 'backend niega POS aunque se manipule la interfaz');
+    [$status] = securityTestRequest($base.'/core.php', 'POST', ['accion'=>'roles'], $cookieFile, true, true);
+    securityTestAssert($status === 403, 'configuracion.ver no permite gestionar roles');
+    $stmt=$db->prepare("INSERT INTO rol_permiso(id_rol,id_permiso) SELECT ?,id_permiso FROM permiso WHERE modulo='configuracion' AND accion='gestionar_roles'");
+    $stmt->bind_param('i',$roleId);$stmt->execute();$stmt->close();
+    [$status] = securityTestRequest($base.'/core.php', 'POST', ['accion'=>'roles'], $cookieFile, true, true);
+    securityTestAssert($status === 200, 'checkbox gestionar_roles habilita la API real');
+    $permissionId=(int)$db->query("SELECT id_permiso FROM permiso WHERE modulo='configuracion' AND accion='gestionar_roles'")->fetch_row()[0];
+    [$status] = securityTestRequest($base.'/core.php', 'POST', ['accion'=>'rol_permiso_toggle','id_rol'=>$roleId,'id_permiso'=>$permissionId], $cookieFile, true, true);
+    securityTestAssert($status === 409, 'no se puede quitar el último acceso administrativo');
+
+    $stmt=$db->prepare('UPDATE core_sesion SET expires_at=DATE_SUB(NOW(),INTERVAL 1 SECOND) WHERE id_user=? AND revoked_at IS NULL');
+    $stmt->bind_param('i',$userId);$stmt->execute();$stmt->close();
+    [$status,,$body] = securityTestRequest($base.'/auth.php?accion=estado', 'GET', null, $cookieFile);
+    securityTestAssert($status === 401, "sesión vencida por inactividad pierde acceso (HTTP {$status}: {$body})");
+    [$status,$login] = securityTestRequest($base.'/auth.php?accion=login', 'POST', ['username'=>$username,'password'=>$password], $cookieFile, true);
+    securityTestAssert($status === 200 && !empty($login['ok']), 'usuario puede iniciar una sesión nueva después de expirar la anterior');
+
+    [$status] = securityTestRequest($base.'/auth.php?accion=logout', 'POST', [], $cookieFile, true);
+    securityTestAssert($status === 200, 'logout termina la sesión actual');
+    $stmt=$db->prepare('SELECT COUNT(*) total FROM core_sesion WHERE id_user=? AND revoked_at IS NOT NULL');
+    $stmt->bind_param('i',$userId);$stmt->execute();$revoked=(int)$stmt->get_result()->fetch_assoc()['total'];$stmt->close();
+    securityTestAssert($revoked === 1, 'logout revoca la sesión en servidor');
+    [$status] = securityTestRequest($base.'/auth.php?accion=estado', 'GET', null, $cookieFile);
+    securityTestAssert($status === 401, 'cookie cerrada no recupera acceso');
+} finally {
+    if ($accountId > 0) {
+        $stmt=$db->prepare('UPDATE cuenta SET id_usuario_propietario=NULL WHERE id_cuenta=?');$stmt->bind_param('i',$accountId);$stmt->execute();$stmt->close();
+    }
+    if ($userId > 0) {
+        $stmt=$db->prepare('DELETE FROM core_sesion WHERE id_user=?');$stmt->bind_param('i',$userId);$stmt->execute();$stmt->close();
+        $stmt=$db->prepare('DELETE FROM usuario WHERE id_user=?');$stmt->bind_param('i',$userId);$stmt->execute();$stmt->close();
+    }
+    if ($roleId > 0) {
+        $stmt=$db->prepare('DELETE FROM rol WHERE id_rol=?');$stmt->bind_param('i',$roleId);$stmt->execute();$stmt->close();
+    }
+    $appKey=(string)($_ENV['APP_KEY'] ?? '');if($appKey==='')$appKey='bluecat-test-only-key';
+    $identityHash=hash_hmac('sha256',strtolower(trim($username)),$appKey);
+    $stmt=$db->prepare('DELETE FROM auth_intento WHERE identity_hash=?');$stmt->bind_param('s',$identityHash);$stmt->execute();$stmt->close();
+    if ($accountId > 0) {
+        $stmt=$db->prepare('DELETE FROM cuenta WHERE id_cuenta=?');$stmt->bind_param('i',$accountId);$stmt->execute();$stmt->close();
+    }
+    if (is_string($cookieFile) && is_file($cookieFile)) unlink($cookieFile);
+}

--- a/Blue-Cat/scripts/verify-security-baseline.php
+++ b/Blue-Cat/scripts/verify-security-baseline.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+$root = dirname(__DIR__);
+$errors = [];
+$requireText = static function (string $relative, string $needle) use ($root, &$errors): void {
+    $path = $root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $relative);
+    $contents = is_file($path) ? file_get_contents($path) : false;
+    if ($contents === false || !str_contains($contents, $needle)) {
+        $errors[] = "Falta '{$needle}' en {$relative}";
+    }
+};
+
+$requireText('assets/api/_security.php', "throw new RuntimeException('APP_KEY no configurada");
+$requireText('assets/api/_security.php', 'securityRequireTransport();');
+$requireText('assets/api/_db.php', 'securityValidateSession');
+$requireText('assets/api/_security.php', 'securityRequireCsrf();');
+$requireText('.htaccess', 'storage');
+$requireText('.htaccess', 'Content-Security-Policy');
+$requireText('database/migrations/020_security_foundation.sql', 'core_sesion');
+$requireText('database/migrations/021_pos_action_permissions.sql', "'pos','asociar_cliente'");
+$requireText('assets/js/security.js', 'renderToast');
+
+$publicFiles = glob($root . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR . '*.html') ?: [];
+foreach ($publicFiles as $file) {
+    $contents = file_get_contents($file);
+    if ($contents !== false && preg_match('/<script[^>]+src=/i', $contents) && !str_contains($contents, '../assets/js/security.js')) {
+        $errors[] = 'Falta security.js en public/' . basename($file);
+    }
+}
+
+$unsafeToastPatterns = [
+    '/(?:toast|showToast)[^{]*\{.{0,300}?\.innerHTML\s*=\s*(?:msg|message)\s*;/s',
+    '/\.innerHTML\s*=\s*[\'\"]<i[^;]+\+\s*(?:msg|message)\s*;/s',
+];
+foreach (glob($root . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . '*.js') ?: [] as $file) {
+    $contents = file_get_contents($file);
+    foreach ($unsafeToastPatterns as $pattern) {
+        if ($contents !== false && preg_match($pattern, $contents)) {
+            $errors[] = 'Toast dinámico inseguro en assets/js/' . basename($file);
+            break;
+        }
+    }
+}
+
+if ($errors) {
+    fwrite(STDERR, "Security baseline: FALLÓ\n- " . implode("\n- ", $errors) . "\n");
+    exit(1);
+}
+fwrite(STDOUT, 'Security baseline: OK (' . count($publicFiles) . " páginas verificadas)\n");


### PR DESCRIPTION
## Qué cambia
- aplica permisos reales y aislamiento por cuenta en APIs sensibles
- incorpora sesiones registradas, CSRF, bloqueo progresivo, contraseñas fuertes y revocación
- protege importaciones, exportaciones, backups, mensajes dinámicos y cabeceras HTTP
- añade APP_KEY única, modo HTTPS obligatorio y documentación TLS local
- agrega migraciones, pruebas negativas y workflow de baseline de seguridad

## Impacto
Cada permiso se valida en backend aunque se manipule la interfaz. Los empleados siguen compartiendo productos y stock de su cuenta, con alcance propio o de cuenta según el rol.

## Validación
- verify-baseline
- test-pos-integrity
- test-promotion-engine
- test-supervisor-authorization
- test-security-foundation --allow-production
- verify-security-baseline
- PHP lint, node --check y git diff --check
- HTTP smoke: API sin sesión 401, backups 403, CSP y nosniff presentes