### PR TITLE
Complete Windows launcher and define commercial Beta roadmap

### DIFF
--- a/Blue-Cat/ROADMAP_BETA.md
+++ b/Blue-Cat/ROADMAP_BETA.md
@@ -1,320 +1,718 @@
-# Blue-Cat: arquitectura de producto y hoja de ruta hacia Beta
+# Blue-Cat: plan ágil hacia la Beta comercial
 
-## 1. Definición del producto
+> Documento canónico de producto y entrega
+>
+> Fecha de corte: 20 de julio de 2026
+>
+> Estado real: **alfa técnica avanzada — Fase 4 en prototipo**
+>
+> Próxima meta: **Beta cerrada instalable, licenciada y operable en dos POS LAN**
 
-Blue-Cat será una aplicación de gestión comercial y punto de venta **local-first**, orientada a minimarkets y pequeños comercios. La instalación principal se ejecutará dentro del negocio y seguirá funcionando aunque se interrumpa Internet. Los terminales POS, computadores, tablets o teléfonos autorizados se conectarán al servidor mediante la red local.
+## 1. Resumen ejecutivo
 
-El producto no debe comercializarse como una “suscripción de por vida”. El concepto correcto es una **licencia perpetua de pago único**, limitada por plan. El cliente conserva el derecho a usar la versión adquirida. Servicios opcionales como actualizaciones mayores, soporte remoto, respaldo en nube o módulos futuros pueden venderse mediante mantenimiento anual sin desactivar la operación local ya licenciada.
+Blue-Cat todavía no está listo para vender licencias ni habilitar descargas automáticas. El núcleo POS tiene una base valiosa —venta atómica e idempotente, caja, pagos mixtos, devoluciones, promociones, aislamiento por cuenta y autorización de supervisor— y ya existe un prototipo de instalador Windows. Sin embargo, hay defectos críticos de permisos e inventario, el instalador no está firmado ni certificado en máquinas limpias, el cliente LAN aún no se empareja con un servidor remoto, y el licenciamiento actual solo consulta tablas locales modificables.
 
-### Principios del producto
+La landing también es una alfa visual. Puede presentar la oferta y recibir solicitudes, pero todavía no posee identidad de clientes, pago automatizado, portal, correo transaccional, emisión de licencias ni descarga protegida. El comercio debe permanecer deshabilitado hasta cerrar sus bloqueadores críticos.
 
-- Operación de caja rápida y disponible sin Internet.
-- Una cuenta comercial comparte productos, stock, clientes y configuración.
-- Cada empleado tiene identidad, rol, permisos y trazabilidad propios.
-- Separación estricta entre cuentas, incluso cuando varias cuentas existen en el mismo servidor.
-- La interfaz nunca sustituye la seguridad: todo permiso se valida también en la API.
-- Instalación, actualización, respaldo y restauración deben ser aptos para usuarios no técnicos.
-- Ningún terminal cliente se conecta directamente a MySQL.
+La secuencia correcta es:
 
-## 2. Arquitectura objetivo
+1. estabilizar y asegurar el producto local;
+2. formalizar planes y capacidades;
+3. construir identidad, pedidos y pagos en la landing;
+4. emitir licencias y artefactos firmados;
+5. integrar activación online/offline sin depender de Internet para vender;
+6. certificar instalación, dos POS LAN, backup, recuperación y actualización;
+7. ejecutar pruebas de usuario y un piloto real antes de cobrar públicamente.
 
-### 2.1 Componentes
+Con tres desarrolladores y apoyo dedicado de QA/seguridad, la estimación responsable es **14 a 18 semanas**; con dos desarrolladores y QA, **18 a 24 semanas**; con una sola persona, **24 a 30 semanas**. La sincronización de sucursales en nube se mantiene como producto mensual separado y comienza después de estabilizar la Beta local.
 
-1. **Blue-Cat Server**
-   - Aplicación PHP y servidor web.
-   - MySQL/MariaDB accesible únicamente desde el equipo servidor.
-   - Servicio de Windows con inicio automático.
-   - Administrador local para instalación, diagnóstico, respaldo y actualización.
-   - API HTTP para todos los clientes.
+## 2. En qué fase estamos
 
-2. **Blue-Cat Client**
-   - Primera opción: navegador o PWA instalada desde el servidor local.
-   - Opción posterior: envoltorio de escritorio liviano para kiosco, accesos directos, impresoras y actualización controlada.
-   - No contiene base de datos empresarial ni credenciales de MySQL.
-   - Descubre o recuerda la dirección del servidor y abre el POS correspondiente.
+| Fase histórica | Estado | Evidencia y brecha principal |
+|---|---|---|
+| 0. Gobierno y repositorio | Parcial | Hay ADR, migraciones, CI y tag inicial; `master` no está protegida y los escaneos de seguridad están desactivados. |
+| 1. Datos y aislamiento | Avanzada, no cerrada | Existen pruebas multicuenta; el API de empleados todavía vulnera la matriz de autorización. |
+| 2. Integridad POS | Avanzada, no cerrada | Venta/caja/pagos tienen buena base; inventario físico, decimales por peso y transacciones de stock tienen defectos críticos. |
+| 3. Permisos y seguridad | Parcial | Hay sesiones, CSRF, auditoría y autorización de supervisor; faltan controles uniformes en todos los endpoints y E2E por rol. |
+| 4. Instalador Windows | Prototipo funcional | Caddy, PHP, MariaDB, servicios y WebView2 existen; faltan firma, release reproducible y certificación en Windows limpio. |
+| 5. Clientes LAN | Inicial | Hay HTTPS LAN; faltan dirección remota, emparejamiento, confianza TLS, registro y revocación de terminales. |
+| 6. Licencias y planes | Diseño solamente | `validar_licencia` lee datos locales; no hay firma asimétrica, activación, servidor de licencias ni enforcement confiable. |
+| 7. Backup/actualización | Inicial | Hay estructura y documentación, pero no un recorrido probado de backup, restore, upgrade y rollback. |
+| 8. Calidad integral | Parcial | Hay suites PHP valiosas; faltan E2E de navegador, visuales, accesibilidad, rendimiento, fallos e instalación automatizada. |
+| 9. Piloto Beta | No iniciada | No existe evidencia de operación real sostenida en comercios piloto. |
 
-3. **Servicio de licencias**
-   - Necesario para activar, transferir y administrar licencias, pero no para procesar cada venta.
-   - Emite una licencia firmada criptográficamente que el servidor puede validar sin Internet.
-   - Permite un periodo de gracia amplio para revalidación y nunca debe interrumpir una venta en curso.
+### Clasificación actual por proyecto
 
-4. **Servicios opcionales en nube**
-   - Respaldo cifrado externo.
-   - Telemetría autorizada y diagnósticos.
-   - Portal de licencias y descarga de actualizaciones.
-   - No son dependencia de la operación cotidiana del POS.
+| Proyecto | Estado | ¿Puede ponerse en producción? |
+|---|---|---|
+| Blue-Cat aplicación local | Alfa avanzada | No; cerrar P0/P1 y regresión integral. |
+| Instalador/launcher Windows | Prototipo de Fase 4 | No; no está firmado ni certificado. |
+| Cliente POS LAN | Diseño/prototipo local | No; solo abre `https://localhost`. |
+| Landing comercial | Alfa visual/técnica | No; mantener compra real deshabilitada. |
+| Portal de cliente | No iniciado | No. |
+| Pagos Mercado Pago | No iniciado | No. |
+| Servicio de licencias | No iniciado | No. |
+| Cloud Sync multisucursal | Descubrimiento | Fuera de la primera Beta local. |
 
-### 2.2 Conexión de varios POS en un minimarket
+## 3. Bloqueadores inmediatos antes de ampliar alcance
 
-El comercio instala **Blue-Cat Server en un solo equipo estable**, preferiblemente un mini PC dedicado, UPS y conexión Ethernet. Todos los dispositivos se conectan al mismo router por cable o Wi-Fi:
+Estos problemas forman el Sprint 1 y bloquean cualquier Beta:
+
+| Prioridad | Problema actual | Riesgo | Resultado exigido |
+|---|---|---|---|
+| P0 | Lectura y mutaciones de empleados sin permisos uniformes en `assets/api/empleados.php` | Fuga de datos personales y escalamiento de privilegios | Toda consulta y acción exige permiso, cuenta y alcance; pruebas negativas por rol. |
+| P0 | Cierre de inventario lee el resultado antes de ejecutar la consulta en `assets/api/inventario.php` | Cierre físico roto/inconsistente | Ejecutar, validar tenant y bloquear dentro de una transacción. |
+| P0 | Cantidades de productos por peso se convierten a entero | Pérdida silenciosa de stock y dinero | Mantener `DECIMAL` de extremo a extremo en conteo, ajuste, transferencia, venta y devolución. |
+| P0 | Varias operaciones de inventario no son transaccionales | Cabecera, detalle, stock y kardex pueden divergir | Transacciones, `SELECT ... FOR UPDATE`, idempotencia y pruebas por interrupción. |
+| P0 | La landing tiene bloqueadores críticos de seguridad y persistencia | No puede recibir pagos ni documentos de clientes con seguridad | Cerrar los hallazgos críticos del informe Full Stack antes de exponer comercio. |
+| P1 | El API de empleados devuelve ruta y línea internas en fallos | Divulgación técnica | Error público genérico más ID correlacionado; detalle solo en logs. |
+| P1 | Migraciones ejecutadas durante requests de empleados | Bloqueos, carreras y despliegues irreproducibles | Usar exclusivamente migraciones versionadas. |
+| P1 | La UI ofrece editar/eliminar ventas confirmadas mientras el backend devuelve `409` | UX engañosa y permisos incoherentes | Eliminar esos permisos/botones; usar anulación/devolución autorizada. |
+| P1 | `master` no protegida y escaneos de secretos/dependencias desactivados | Releases sin control e incidentes evitables | Protección, revisiones, CI requerido, Secret Scanning/Push Protection y Dependabot. |
+| P1 | Desinstalación puede purgar datos sin un backup obligatorio | Pérdida total del comercio | Retención por defecto; borrado explícito con doble confirmación y backup verificado. |
+
+El detalle técnico de la landing está en [`blue-cat-landing/docs/full-stack-audit-2026-07-20.md`](../blue-cat-landing/docs/full-stack-audit-2026-07-20.md).
+
+## 4. Producto comercial objetivo
+
+### 4.1 Oferta inicial
+
+| Producto | Forma de cobro | Alcance objetivo |
+|---|---|---|
+| Blue-Cat PYME Standard | Pago único | Una empresa local, operación POS/inventario, límites definidos de usuarios, cajas, terminales y sucursales. |
+| Blue-Cat Enterprise | Pago único o cotización asistida | Capacidades, límites y soporte ampliados; automatización, integraciones y despliegue administrado. |
+| Mantenimiento de actualizaciones | Incluido 12 meses; renovación opcional | Acceso a releases publicados durante la vigencia. La versión perpetua ya adquirida no se desactiva. |
+| Cloud Sync multisucursal | Suscripción mensual separada | Sincronización y operación coordinada entre servidores geográficamente separados. No es requisito del POS local. |
+
+La definición final de precios, límites, impuestos, soporte, devoluciones, transferencia de equipo y SLA debe aprobarse en Sprint 0. Hoy existen nombres incompatibles —Single/Emprendedor/Negocio/Enterprise, PYME/Enterprise y “Beta Completa”— que no pueden llegar al licenciamiento.
+
+### 4.2 Un producto base, capacidades distintas
+
+PYME y Enterprise sí deben comportarse de manera diferente, pero no conviene mantener dos forks del código. Se construirá un núcleo firmado por versión y un catálogo inmutable de SKU/capacidades. El portal puede entregar bundles distintos —servidor, cliente POS y conectores Enterprise—, pero la autorización real proviene de un entitlement firmado y se valida también en el backend.
 
 ```text
-Internet (opcional)
-        |
-     Router LAN
-       / | \
-      /  |  \
-Server  POS 1  POS 2 / tablet
-PHP+DB  navegador/PWA navegador/PWA
+acción permitida = capacidad de licencia
+                  AND permiso del usuario
+                  AND alcance de cuenta/sucursal
+                  AND cuota disponible
 ```
 
-El servidor tendrá una reserva DHCP o IP fija. Los clientes accederán mediante una dirección como `https://bluecat.local` o `https://192.168.1.20`. Se puede agregar descubrimiento mDNS, pero siempre debe existir configuración manual como respaldo.
+Ocultar un módulo en la navegación solo mejora la UX; nunca reemplaza este control.
 
-El instalador del servidor deberá:
+### 4.3 Decisión recomendada para la primera Beta
 
-- detectar la red privada;
-- solicitar autorización para abrir solo el puerto web en el firewall privado;
-- mantener MySQL escuchando únicamente en `127.0.0.1`;
-- mostrar un código QR y URL para conectar terminales;
-- registrar dispositivos autorizados;
-- comprobar conectividad y latencia;
-- advertir si el servidor usa Wi-Fi, cambia de IP o carece de respaldo.
+- Automatizar la compra de **PYME Standard** cuando todo su recorrido esté certificado.
+- Mantener **Enterprise** como “solicitar cotización” hasta probar sus capacidades y límites reales.
+- Mantener **Cloud Sync** como “solicitar evaluación” hasta completar su arquitectura, seguridad, monitoreo y recuperación.
+- No prometer sincronización entre sucursales mediante replicación directa de bases de datos. Ese servicio requiere eventos, outbox, idempotencia, resolución de conflictos y operación observada.
 
-Para Beta no se recomienda una base de datos independiente en cada POS: sincronizar ventas, stock y cajas agrega conflictos difíciles. Si el servidor se apaga, los clientes de la red dejan de operar; esto se mitiga con equipo dedicado, UPS, inicio automático, health checks y recuperación rápida. Un modo POS desconectado con cola local puede evaluarse después de la versión estable.
+## 5. Arquitectura del ecosistema
 
-## 3. Modelo SaaS/local multiusuario
+```mermaid
+flowchart LR
+    C["Cliente / navegador"] --> L["Landing y portal"]
+    L --> I["Identidad y organizaciones"]
+    L --> O["Pedidos y pagos"]
+    O --> MP["Mercado Pago"]
+    MP -->|"webhook firmado"| O
+    O --> F["Fulfillment idempotente"]
+    F --> LS["Servicio de licencias"]
+    F --> R["Catálogo de releases y descargas"]
+    LS -->|"licencia/activación firmada"| S["Blue-Cat Server local"]
+    R -->|"artefacto firmado"| S
+    P1["POS 1"] -->|"HTTPS LAN"| S
+    P2["POS 2"] -->|"HTTPS LAN"| S
+    S -.->|"opcional y contratado"| CS["Cloud Sync"]
+```
 
-La unidad de aislamiento es `cuenta`. Una cuenta contiene usuarios, empleados, sucursales, bodegas, productos, existencias, cajas, sesiones, pedidos, clientes y configuración. Todas las tablas de negocio deben pertenecer de forma directa o derivable a una cuenta.
+### 5.1 Separación de datos
 
-### Reglas obligatorias
+- La base operacional local conserva productos, stock, ventas, cajas, clientes, empleados y auditoría.
+- El control plane en Internet conserva cuentas del portal, organizaciones, pedidos, pagos, licencias, dispositivos, releases, descargas y soporte.
+- Cloud Sync solo puede acceder a datos operacionales cuando el cliente lo contrata y consiente expresamente.
+- Ningún POS cliente se conecta directamente a MariaDB; todos consumen la API del servidor local.
 
-- Un administrador solo administra su cuenta.
-- Un empleado pertenece a una cuenta y puede estar vinculado a una sucursal.
-- `ver` permite consultar registros propios o del alcance asignado.
-- `ver_todos` amplía la consulta únicamente dentro de la misma cuenta.
-- `crear`, `editar`, `eliminar`, `exportar`, `abrir_caja`, `cerrar_caja`, `anular` y acciones sensibles son permisos separados.
-- Los filtros de cuenta se aplican en SQL/API, no después de obtener datos.
-- Todo cambio crítico genera auditoría válida e inmutable.
-- Los roles incluidos por defecto pueden clonarse, pero nunca compartirse accidentalmente entre cuentas.
+### 5.2 Modelo mínimo del control plane
 
-## 4. Planes comerciales propuestos
+| Dominio | Entidades principales |
+|---|---|
+| Identidad | `users`, `credentials`, `email_verifications`, `password_resets`, `sessions`, `mfa_factors` |
+| Organizaciones | `organizations`, `memberships`, `billing_profiles`, `consents` |
+| Catálogo | `product_skus`, `plan_revisions`, `capabilities`, `sku_entitlements`, `prices` |
+| Comercio | `orders`, `order_items`, `quotes`, `payments`, `payment_attempts`, `provider_events`, `refunds` |
+| Licencias | `entitlements`, `licenses`, `license_entitlements`, `activations`, `devices`, `revocations`, `license_events` |
+| Distribución | `releases`, `artifacts`, `manifests`, `download_grants`, `download_events` |
+| Cloud | `cloud_subscriptions`, `cloud_tenants`, `sync_nodes` |
+| Operación | `outbox_messages`, `email_deliveries`, `audit_events`, `support_cases` |
 
-Los límites deben definirse en una tabla de capacidades y validarse en servidor. “Usuario” significa una credencial activa; “dispositivo POS” significa un terminal autorizado. No conviene limitar sesiones del navegador de forma ambigua.
+Los estados de pedido, pago, fulfillment y licencia deben ser máquinas de estado separadas. “Pago aprobado” no equivale a “licencia emitida” hasta que el fulfillment termine de forma idempotente.
 
-| Plan | Usuarios activos | POS autorizados | Sucursales | Alcance sugerido |
-|---|---:|---:|---:|---|
-| Single | 1 | 1 | 1 | Dueño que atiende su caja |
-| Emprendedor | 4 | 2 | 1 | Minimarket pequeño |
-| Negocio | 10 | 5 | 2 | Comercio con turnos y administración |
-| Enterprise | Configurable | Configurable | Configurable | Varias sucursales, soporte y despliegue administrado |
+## 6. Recorrido completo del cliente
 
-Decisiones comerciales pendientes antes de Beta:
+1. El visitante compara PYME, Enterprise y Cloud Sync.
+2. Crea una cuenta del portal con correo y acepta términos/privacidad.
+3. Recibe un enlace aleatorio, de un solo uso y expiración corta para verificar el correo y definir su contraseña.
+4. Crea o confirma su organización y datos de facturación.
+5. Elige un SKU y el servidor crea un pedido inmutable con precio, moneda, impuestos y revisión del plan.
+6. Paga mediante Mercado Pago o elige transferencia bancaria asistida.
+7. El backend verifica el pago; jamás confía en la URL de retorno del navegador.
+8. Fulfillment crea una sola vez el entitlement, la licencia y el permiso de descarga correspondientes al pedido.
+9. El cliente recibe un correo con el enlace al portal y la disponibilidad de la descarga. No recibe una contraseña en texto plano.
+10. Descarga un instalador/bundle firmado mediante un grant temporal y reemitible.
+11. Instala Blue-Cat Server y activa online o mediante desafío/respuesta offline.
+12. En el primer inicio crea la contraseña del administrador local. Esta identidad es distinta a la cuenta del portal.
+13. El asistente configura empresa, sucursal, bodega, caja, moneda, impuestos, numeración, boleta, logo y backup.
+14. Empareja cada POS LAN por código/QR aprobado por un administrador.
+15. Crea empleados locales, roles y permisos; opera aun sin Internet.
+16. El portal permite ver licencia, dispositivos, descargas elegibles, soporte y renovación de mantenimiento/Cloud.
 
-- si el precio incluye actualizaciones menores para siempre;
-- duración del soporte inicial incluido;
-- precio por usuarios, POS o sucursales adicionales;
-- política de transferencia a otro computador;
-- reemplazo por falla de hardware;
-- módulos incluidos por plan;
-- condiciones del respaldo en nube opcional.
+### 6.1 Identidades que no deben mezclarse
 
-## 5. Fases para llegar a Beta
+| Identidad | Propósito | Dependencia de Internet |
+|---|---|---|
+| Cuenta del portal | Compra, pagos, licencias, descargas, dispositivos y soporte | Sí para el portal |
+| Administrador local Blue-Cat | Configura y administra el comercio | No para operación normal |
+| Empleados locales | Cajero, supervisor, bodeguero y otros roles auditables | No para operación normal |
 
-### Fase 0 — Gobierno del producto y repositorio
+El correo nunca debe contener una contraseña permanente. El secreto se define mediante enlace de un solo uso; las contraseñas se almacenan con Argon2id y las sesiones pueden revocarse.
 
-**Objetivo:** establecer una línea base reproducible.
+## 7. Pagos y entrega
 
-- Definir propietario, alcance Beta y decisiones técnicas registradas mediante ADR.
-- Configurar remoto Git, ramas protegidas, revisión y versiones semánticas.
-- Eliminar duplicados legacy y declarar una única API activa.
-- Separar datos de demostración, migraciones y datos reales.
-- Crear entornos desarrollo, prueba, piloto y producción local.
-- Incorporar análisis de secretos y dependencias.
+### 7.1 Mercado Pago
 
-**Salida:** una instalación limpia puede construirse desde Git y todos conocen qué entra o no en Beta.
+La opción recomendada es Checkout Pro:
 
-### Fase 1 — Modelo de datos y aislamiento de cuenta
+1. Blue-Cat crea un pedido local y una preferencia de pago desde el backend.
+2. Envía el ID del pedido como `external_reference` y persiste los IDs del proveedor.
+3. Redirige al `init_point` devuelto por Mercado Pago.
+4. Recibe y valida la firma del webhook.
+5. Deduplica el evento y consulta el pago server-to-server.
+6. Comprueba pedido, monto, moneda, estado y beneficiario.
+7. Emite el entitlement de forma idempotente.
+8. Un reconciliador periódico recupera webhooks perdidos o desordenados.
 
-**Objetivo:** hacer confiable el núcleo multiusuario.
+La pantalla de “pago exitoso” no entrega acceso por sí sola. También deben probarse pagos pendientes/rechazados, duplicados, reembolsos y contracargos. Un link de pago estático puede ser contingencia, no el fundamento de provisioning automático.
 
-- Inventariar tablas y agregar alcance de cuenta donde corresponda.
-- Definir claves foráneas, índices, unicidad y reglas de borrado.
-- Reemplazar scripts SQL acumulativos por migraciones ordenadas y versionadas.
-- Crear servicio común de contexto: cuenta, usuario, sucursal, bodega y caja.
-- Revisar cada endpoint contra fugas entre cuentas.
-- Asegurar roles propios de cada cuenta o plantillas globales de solo lectura.
-- Preparar migración de datos existentes y rollback probado.
+Referencias oficiales: [Checkout Pro](https://www.mercadopago.cl/developers/es/docs/checkout-pro/overview), [API de pagos/preferencias](https://www.mercadopago.cl/developers/es/reference/online-payments/checkout-pro/overview) y [Webhooks y firma](https://www.mercadopago.cl/developers/es/docs/your-integrations/notifications/webhooks).
 
-**Salida:** pruebas automatizadas demuestran que una cuenta nunca puede leer o modificar datos de otra.
+### 7.2 Transferencia bancaria
 
-### Fase 2 — Integridad funcional del POS
+La transferencia manual puede mantenerse, especialmente para Enterprise, con este control:
 
-**Objetivo:** ninguna venta puede dejar stock, pagos o caja inconsistentes.
+- un pedido previo proporciona referencia y monto exacto;
+- el comprobante se guarda en almacenamiento privado, no en una carpeta pública;
+- se valida tipo, tamaño y contenido, se renombra, se analiza y se registra auditoría;
+- la consola interna exige MFA y RBAC;
+- una persona revisa y, para montos altos, otra aprueba;
+- la conciliación bancaria prevalece sobre la imagen del comprobante;
+- solo el estado conciliado inicia fulfillment;
+- la aprobación es idempotente y reversible mediante el flujo de reembolso/revocación definido.
 
-- Venta atómica con transacción de base de datos.
-- Idempotencia para impedir ventas duplicadas por doble clic o reintento.
-- Productos por unidad, peso y volumen con precisión decimal definida.
-- Pagos mixtos, vuelto, efectivo, tarjeta y transferencia normalizados.
-- Apertura y cierre por caja física y cajero.
-- Anulación/devolución con autorización, motivo, stock y auditoría.
-- Folios/documentos e impresión tolerante a fallas.
-- Control de concurrencia cuando dos POS venden el último producto.
-- Cuadre por sesión con ventas, pagos, retiros, ingresos y diferencias.
+## 8. Licenciamiento seguro y funcionamiento offline
 
-**Salida:** escenarios críticos pasan pruebas repetibles y el stock nunca queda negativo salvo política explícita.
+### 8.1 Modelo
 
-### Fase 3 — Permisos y seguridad
+- **Entitlement:** lo que el cliente compró, con SKU, revisión, capacidades, límites y mantenimiento.
+- **Licencia:** proyección canónica firmada de ese derecho.
+- **Activación:** consumo autorizado del derecho por una instalación/dispositivo.
 
-**Objetivo:** cada casilla de permiso produce un efecto real y verificable.
+El payload de licencia debe incluir, como mínimo: formato, IDs, producto, edición, revisión inmutable, `perpetual_use`, `maintenance_until`, capacidades, límites, instalación/dispositivo, emisión y `kid`. Se firma con Ed25519; el algoritmo aceptado lo decide el código por `kid`, nunca el payload no confiable.
 
-- Catálogo canónico de permisos y descripción comprensible.
-- Middleware único para autenticación, cuenta, rol y acción.
-- Matriz automatizada de rol × endpoint × alcance.
-- CSRF, cookies seguras, regeneración de sesión y cierre por inactividad.
-- Rate limiting y bloqueo progresivo de inicio de sesión.
-- Política de contraseñas y recuperación administrada.
-- Validación de entradas, cargas de archivos y salidas contra XSS.
-- Auditoría estructurada que nunca interrumpe operaciones.
-- Encabezados de seguridad y TLS en la red local.
+La clave privada permanece en KMS/HSM del control plane. El instalador solo contiene claves públicas. Deben separarse las claves de licencias, manifiestos de actualización, firma Authenticode y Cloud Sync, con rotación y auditoría.
 
-**Salida:** pruebas negativas confirman que ocultar o manipular botones/requests no evita los controles del servidor.
+### 8.2 Activación
 
-### Fase 4 — Aplicación servidor e instalador
+1. La instalación genera un ID aleatorio y un par de claves de dispositivo.
+2. La clave privada se protege con TPM/CNG cuando exista; fallback CNG no exportable más DPAPI `LocalMachine` y ACL restrictiva.
+3. El servidor envía licencia, clave pública, nonce y prueba de posesión.
+4. El control plane valida entitlement, estado y cuota transaccionalmente.
+5. Devuelve un certificado de activación firmado y ligado a esa instalación.
+6. Blue-Cat lo valida localmente y lo almacena protegido.
 
-**Objetivo:** instalar Blue-Cat Server en Windows sin Laragon manual.
+Para equipos sin Internet, Blue-Cat genera un `.bcreq`; el cliente lo sube desde otro dispositivo y descarga un `.bclic` firmado. El nonce es de un solo uso y el proceso es idempotente.
 
-- Elegir runtime empaquetado y con licencia redistribuible: servidor web, PHP y MySQL/MariaDB.
-- Crear servicio de Windows y supervisor de procesos.
-- Instalador firmado con instalación, reparación y desinstalación.
-- Asistente inicial: empresa, administrador, moneda, impuestos, bodega y caja.
-- Creación automática de base de datos y migraciones.
-- Directorios separados para aplicación, configuración, datos, logs y backups.
-- Health check local y panel de diagnóstico.
-- No incluir contraseñas predeterminadas conocidas.
+### 8.3 Reglas de negocio y disponibilidad
 
-**Salida:** una máquina Windows limpia queda operativa después de un único instalador y reinicio.
+- Una licencia perpetua activa sigue permitiendo usar la versión elegible aunque termine el mantenimiento.
+- El fin de los 12 meses bloquea releases posteriores, no las ventas locales.
+- El fin de Cloud Sync detiene la nube, no el POS local.
+- No se consulta Internet por cada venta ni apertura de caja.
+- Una caída del servicio de licencias por 72 horas no debe detener una instalación ya activada.
+- Revocación puede impedir nuevas activaciones, descargas y Cloud; no existe revocación instantánea garantizable en un equipo perpetuo completamente desconectado.
 
-### Fase 5 — Clientes LAN y dispositivos
+### 8.4 Controles contra keygen, inyección y manipulación
 
-**Objetivo:** conectar múltiples POS de forma sencilla y segura.
+- firmas asimétricas y verificación canónica;
+- `kid`/algoritmos permitidos por código y rotación de claves;
+- vínculo a la clave del dispositivo, nonce y protección contra replay;
+- cuotas de activación con bloqueo transaccional;
+- listas de revocación y manifiestos firmados monotónicos;
+- releases, hashes, fecha elegible y migraciones en manifiesto firmado;
+- instalador/launcher firmados con Authenticode y timestamp;
+- grants de descarga aleatorios, hash almacenado, expiración de 10–30 minutos y auditoría;
+- enforcement de plan y permisos en backend, no solo JavaScript;
+- SAST, DAST, fuzzing de parser de licencia, SBOM, escaneo de secretos/dependencias;
+- servicio/verificador nativo firmado para elevar el costo de parcheo local; ofuscación solo como defensa secundaria.
 
-- PWA responsive con modo kiosco y acceso directo.
-- Pantalla del servidor con URL, QR y estado de red.
-- Emparejamiento mediante código temporal y aprobación del administrador.
-- Registro, nombre, revocación y límite de dispositivos según plan.
-- Detección de servidor por mDNS más entrada manual.
-- Pruebas con Ethernet, Wi-Fi, cambios de IP y reinicios del router.
-- Compatibilidad con impresora térmica, lector de código como teclado y balanza según alcance.
+Un administrador de Windows controla físicamente su máquina y puede parchear PHP/binarios. El objetivo realista es impedir falsificación criptográfica, detectar alteración, proteger servicios comerciales y elevar el costo del bypass; no prometer DRM invulnerable.
 
-**Salida:** dos POS venden simultáneamente contra un servidor local sin conflictos ni acceso directo a la base de datos.
+## 9. Forma de trabajo ágil
 
-### Fase 6 — Licencia perpetua y planes
+### 9.1 Cadencia y equipos
 
-**Objetivo:** proteger el producto sin hacer dependiente la caja de Internet.
+- Sprints de dos semanas; Sprint 0 de una semana.
+- Demo funcional y retrospectiva al cierre de cada sprint.
+- Refinamiento semanal y triage diario de P0/P1.
+- Un solo backlog del ecosistema, con cuatro carriles: núcleo Blue-Cat, instalador/LAN/licencia, landing/comercio y QA/seguridad/release.
+- Límite de WIP: ninguna persona mantiene más de una historia principal y una corrección urgente simultáneas.
+- Feature flags y `commerce kill switch` para no exponer flujos incompletos.
 
-- Licencia firmada con clave privada fuera del instalador.
-- Activación online y alternativa offline por archivo/desafío-respuesta.
-- Identificador de instalación tolerante a cambios menores de hardware.
-- Capacidades por plan, usuarios, dispositivos, sucursales y módulos.
-- Transferencia/revocación de licencia y recuperación por falla.
-- Periodo de gracia para validación; nunca validar en cada venta.
-- Pantallas claras de estado, límites y acciones de solución.
-- Contrato de licencia perpetua y política de actualizaciones.
+Roles mínimos: Product Owner, Tech Lead/arquitecto, backend, frontend/UX, QA automatización/UAT y responsable de release/seguridad. En un equipo pequeño una persona puede cubrir varios roles, pero Product Owner y aprobación QA no deben confundirse en tareas de alto riesgo.
 
-**Salida:** manipular fecha, archivo o respuesta de red no concede capacidades; una caída de Internet no detiene el POS.
+### 9.2 Definition of Ready
 
-### Fase 7 — Respaldo, actualización y recuperación
+Una historia entra a sprint cuando contiene:
 
-**Objetivo:** hacer operable el producto durante años.
+- persona, valor y criterio de aceptación observable;
+- UX y estados vacío/loading/error/offline cuando corresponda;
+- contrato API/datos y migración;
+- permisos, tenant y amenazas relevantes;
+- dependencia de hardware/proveedor;
+- estrategia de pruebas, rollback y telemetría/auditoría.
 
-- Backups automáticos cifrados, rotación y verificación de integridad.
-- Exportación manual a USB y destino externo opcional.
-- Restauración asistida probada, no solo creación del backup.
-- Actualizador firmado con migración, backup previo y rollback.
-- Canal estable y canal piloto.
-- Logs estructurados, rotación y paquete de diagnóstico sin datos sensibles.
-- Procedimiento documentado para reemplazar el servidor.
+### 9.3 Definition of Done
 
-**Salida:** se restaura una instalación completa en otra máquina y se recupera de una actualización fallida.
+Una historia termina solo cuando:
 
-### Fase 8 — Calidad, rendimiento y observabilidad
+- código revisado y sin secretos;
+- control aplicado en UI y backend;
+- pruebas unitarias, integración y E2E relevantes pasan;
+- aislamiento, permisos, concurrencia y casos negativos pasan;
+- migración, backup y rollback están definidos si cambia datos;
+- UX visual, teclado, accesibilidad y responsive verificados;
+- logs/auditoría no exponen secretos;
+- documentación y soporte actualizados;
+- CI obligatorio en verde y artefacto reproducible cuando aplique.
 
-**Objetivo:** medir que el sistema cumple su promesa.
+### 9.4 Estrategia de ramas y releases
 
-- Pruebas unitarias de dinero, stock, permisos y licencias.
-- Pruebas de integración sobre MySQL real.
-- Pruebas E2E de login, apertura, venta, anulación, cierre y exportación.
-- Pruebas de concurrencia con varios POS.
-- Presupuesto de rendimiento: acciones POS comunes por debajo de 300 ms en LAN.
-- Pruebas de recuperación tras corte de energía y reinicio abrupto.
-- Matriz de navegadores, resoluciones, impresoras y lectores compatibles.
-- Escaneo de seguridad y revisión de configuración de producción.
+- `master` protegida, sin push directo y con checks obligatorios.
+- Ramas `codex/` o `feature/` cortas y PR revisado.
+- Conventional Commits o convención equivalente y versionado semántico.
+- Canales `dev`, `pilot` y `stable`.
+- Cada tag produce artefacto inmutable, checksum, SBOM, manifiesto y release notes.
+- No crear un tag Beta hasta pasar todos los gates de su alcance.
 
-**Salida:** pipeline verde, cero defectos críticos abiertos y métricas dentro del presupuesto.
+## 10. Roadmap por sprints
 
-### Fase 9 — Piloto Beta
+Las fechas comienzan cuando se aprueba Sprint 0 y existe capacidad asignada. Los Sprints 0–12 representan incrementos lógicos y dependencias: con un solo equipo son secuenciales; con varios equipos, los carriles de núcleo local y control plane pueden solaparse, pero sus gates no se omiten.
 
-**Objetivo:** validar el producto en comercios reales con riesgo controlado.
+### Sprint 0 — Decisiones y línea base (1 semana)
 
-- Seleccionar entre 3 y 5 comercios con hardware diverso.
-- Levantar inventario y capacitar a usuarios.
-- Ejecutar en paralelo con el sistema anterior durante un periodo acordado.
-- Canal de soporte, severidades y tiempos de respuesta.
-- Telemetría opcional con consentimiento y anonimización.
-- Revisión semanal de incidentes y priorización.
-- Congelamiento de alcance antes del lanzamiento Beta público.
+**Objetivo:** congelar qué se vende y desde qué baseline.
 
-**Salida:** al menos dos semanas operativas sin pérdida de ventas, stock ni datos y con restauración probada.
+- aprobar PYME/Enterprise/Cloud, límites, precios, impuestos, soporte, reembolso, transferencia y mantenimiento;
+- publicar catálogo de SKU/capacidades versionado;
+- decidir Enterprise automatizado o cotización asistida;
+- registrar ADR de control plane, identidad, pagos y licencias;
+- proteger `master`, activar escaneos y resolver cambios locales/PR pendientes;
+- clasificar toda la deuda P0/P1 y asignar responsables;
+- preparar entornos local, CI, sandbox, piloto y producción.
 
-## 6. Alcance recomendado para la primera Beta
+**Salida:** backlog priorizado, catálogo aprobado, threat model inicial y build reproducible.
+
+### Sprint 1 — Estabilización crítica Blue-Cat y landing
+
+**Objetivo:** recuperar una base segura antes de agregar comercio.
+
+- corregir permisos/errores/migraciones en empleados;
+- corregir inventario físico, decimales y transacciones;
+- alinear ventas inmutables con botones/permisos;
+- asegurar retención de datos y backup antes de desinstalar;
+- cerrar los cinco bloqueadores críticos de la auditoría de landing;
+- incorporar suites de seguridad, supervisor, bootstrap e instalador al CI.
+
+**Salida:** cero P0 conocidos en identidad local, stock y venta; CI cubre las suites existentes.
+
+### Sprint 2 — Identidad del portal y organizaciones
+
+**Objetivo:** crear una cuenta comercial segura.
+
+- registro, verificación de correo, login/logout, recuperación y sesiones;
+- Argon2id, rate limiting, CSRF, cookies seguras y MFA para operadores internos;
+- organizaciones, membresías, consentimiento y perfil de facturación;
+- outbox de correo, reintentos, plantillas y trazabilidad;
+- portal mínimo con estado de cuenta.
+
+**Salida:** una cuenta verificada puede crear su organización; no se envían contraseñas.
+
+### Sprint 3 — Catálogo, pedidos y transferencia segura
+
+**Objetivo:** vender una revisión exacta de producto sin ambigüedad.
+
+- catálogo inmutable, precios, impuestos, cotizaciones y pedidos;
+- portal de pedido/estado/historial;
+- máquina de estados y claves de idempotencia;
+- transferencia con referencia, carga privada, revisión, conciliación y doble control;
+- consola interna restringida y auditada.
+
+**Salida:** una transferencia sandbox conciliada produce exactamente una orden pagada, todavía sin licencia automática.
+
+### Sprint 4 — Mercado Pago y conciliación
+
+**Objetivo:** automatizar pago sin confiar en el navegador.
+
+- adaptador de proveedores y Checkout Pro sandbox;
+- preferencias ligadas al pedido y `external_reference`;
+- webhook firmado, deduplicación, consulta server-to-server y reconciliador;
+- pendientes, rechazados, duplicados, reembolso y contracargo;
+- observabilidad y kill switch.
+
+**Salida:** cada escenario sandbox deja estado consistente y nunca duplica fulfillment.
+
+### Sprint 5 — Operación comercial y portal cliente
+
+**Objetivo:** hacer operable compra y soporte.
+
+- consola con MFA/RBAC, búsqueda y segregación de funciones;
+- portal de licencias, dispositivos, pedidos, facturas/recibos y soporte;
+- auditoría, retención, privacidad y exportación/borrado según política;
+- alertas de pago/fulfillment y runbooks.
+
+**Salida:** soporte puede explicar y recuperar cualquier pedido usando IDs correlacionados sin tocar la base manualmente.
+
+### Sprint 6 — Servicio de licencias
+
+**Objetivo:** emitir derechos verificables offline.
+
+- servicio de entitlement/licencia con firma Ed25519 y claves protegidas;
+- activación, desactivación, transferencia, reemplazo y cuotas;
+- online y desafío/respuesta offline;
+- rotación, revocación, reloj alterado, replay y auditoría;
+- pruebas unitarias/fuzz del formato canónico.
+
+**Salida:** una licencia alterada o clonada se rechaza; la válida sobrevive sin Internet.
+
+### Sprint 7 — Releases, artefactos y fulfillment
+
+**Objetivo:** entregar el producto correcto y verificable.
+
+- catálogo de releases/artefactos por SKU y canal;
+- build reproducible, Authenticode, timestamp, hashes, SBOM y manifiesto firmado;
+- grants temporales de descarga e historial;
+- fulfillment idempotente pago → entitlement → licencia → descarga → correo;
+- conservar la última versión elegible al terminar mantenimiento.
+
+**Salida:** un pedido pagado entrega exactamente el bundle permitido y toda descarga es trazable.
+
+### Sprint 8 — Enforcement local de planes
+
+**Objetivo:** aplicar PYME/Enterprise aun con requests manipulados.
+
+- reemplazar autoridad de tablas locales por licencia/activación firmada;
+- validar capacidades y cuotas en un servicio único del backend;
+- retirar creación local arbitraria de planes/módulos;
+- integrar UI de estado, límites, gracia y recuperación;
+- matriz plan × capacidad × endpoint × usuario;
+- no bloquear venta por caída del control plane.
+
+**Salida:** modificar UI, tabla local, fecha o request no concede una capacidad.
+
+### Sprint 9 — Instalador, LAN y continuidad
+
+**Objetivo:** instalar y operar dos cajas reales.
+
+- instalador firmado, repair/upgrade/uninstall y política de datos;
+- asistente inicial y acceso directo con launcher WebView2;
+- URL remota, QR/código de emparejamiento, CA/TLS local y revocación;
+- diagnóstico de puerto/firewall/IP/router;
+- backup automático/manual, restore en otra máquina y rollback de update;
+- dos terminales asociados a cajas físicas distintas.
+
+**Salida:** una VM limpia y dos POS LAN completan instalación, activación, venta y recuperación.
+
+### Sprint 10 — E2E funcional, visual y de usuario
+
+**Objetivo:** certificar el recorrido operativo completo.
+
+- automatizar los recorridos P0 de la sección 11;
+- Playwright visual/responsive/accesibilidad;
+- pruebas moderadas con dueño, cajero, supervisor y bodeguero;
+- impresión, scanner y balanza si están dentro del SKU;
+- corregir todos los defectos críticos/altos.
+
+**Salida:** Gate Beta cerrada cumplido y release candidate en canal `pilot`.
+
+### Sprint 11 — Seguridad, rendimiento y recuperación
+
+**Objetivo:** probar condiciones adversas.
+
+- pentest de control plane, portal, licencias, LAN y archivos;
+- concurrencia, jornada de ocho horas, DB creciente y p95 LAN;
+- cortes de PHP/DB/Caddy/energía, disco lleno y reloj alterado;
+- simulacros de clave comprometida, proveedor de pago caído y restore;
+- revisión legal/licencias de terceros, privacidad y política comercial.
+
+**Salida:** cero P0/P1, objetivos de rendimiento y runbooks aprobados.
+
+### Sprint 12 — Piloto y Go/No-Go
+
+**Objetivo:** validar el sistema en operación real.
+
+- instalar en 3–5 comercios o, como mínimo inicial, 2 pilotos representativos;
+- capacitación, inventario inicial y operación paralela acordada;
+- soporte con severidades, SLA piloto y revisión diaria/semanal;
+- mínimo dos semanas sin pérdida de venta, stock, caja ni datos;
+- restauración real y actualización controlada durante el piloto;
+- cierre de defectos y decisión Go/No-Go documentada.
+
+**Salida:** Beta comercial limitada o extensión del piloto con razones objetivas.
+
+## 11. Matriz obligatoria de pruebas de aceptación
+
+### 11.1 Instalación, activación y configuración
+
+- Windows 10/11 limpio, sin Laragon: instalar, reiniciar, iniciar servicios, shortcut y WebView2.
+- Puerto 443 ocupado, firewall bloqueado, sin Internet, antivirus, espacio insuficiente y ruta con espacios/acentos.
+- Activación PYME/Enterprise online y offline; licencia inválida, revocada, clonada, sin cuota y con reloj manipulado.
+- Primer inicio: empresa, sucursal, bodega, caja, moneda, IVA/otro impuesto, numeración, plantilla, logo y backup.
+- Upgrade con copia de datos reales, migración, conteos/FK y rollback.
+- Repair y desinstalación conservando datos por defecto; purga solo con confirmación y backup verificable.
+
+### 11.2 Catálogo e inventario
+
+- crear/editar/desactivar categorías, marcas, productos y variantes;
+- SKU/código de barras único; producto unitario y por peso/volumen;
+- separar “actualizar stock” de “actualizar costo/precio/impuesto” y registrar ticket/razón;
+- entradas, salidas, ajustes, transferencias, inventario físico, kardex y alertas;
+- cantidades `0,125`, `0,500` y `1,275` sin truncamiento;
+- costo neto/bruto, IVA configurable, margen y redondeo monetario;
+- importación/exportación XLS/XLSX: válido, nulos, duplicados, errores por fila, archivo grande, fórmula maliciosa y round-trip.
+
+### 11.3 Empleados, roles y permisos
+
+- crear, editar, desactivar, desvincular y eliminar credenciales con política de conservación/auditoría;
+- roles cajero, supervisor y bodeguero sin duplicados;
+- matriz positiva/negativa por UI y request API directo;
+- cambio de permiso se refleja en inicio, navbar, módulo y endpoint;
+- empleado comparte productos/stock de su cuenta, nunca los de otra cuenta;
+- cajero ve sus ventas en solo lectura; administrador ve el alcance autorizado;
+- revocar usuario invalida todas sus sesiones inmediatamente;
+- datos sensibles de RR.HH. requieren permisos específicos.
+
+### 11.4 Caja y venta POS
+
+- abrir una caja física; impedir doble apertura incompatible y recuperar sesión tras reload/reinicio;
+- buscar/agregar producto por SKU, código de barras y catálogo;
+- producto por peso: modal, decimal, precio calculado y stock coherente;
+- buscar, seleccionar, cambiar y retirar cliente de la venta;
+- promociones 2x1/3x2, descuento, precio especial, combo, categoría, cliente, fecha, límites, prioridad y no acumulables;
+- retirar automáticamente beneficio cuando deja de cumplirse la condición;
+- efectivo, transferencia, tarjeta, débito y pago mixto; vuelto y redondeo;
+- doble clic/reintento de red no duplica venta, pago, folio ni stock;
+- dos POS compiten por la última unidad: solo uno confirma;
+- venta aparece en “hoy” según `America/Santiago`, ventas y cuadre inmediatamente;
+- boleta con logo, descuento, precio original/final, cliente, pagos y promoción; impresión fallida no duplica venta;
+- cierre exacto, faltante y sobrante con auditoría.
+
+### 11.5 Supervisor, devoluciones y auditoría
+
+- cajero solicita anulación/devolución/override desde su pantalla;
+- supervisor autoriza con código/tarjeta temporal ligado a operación, un solo uso y expiración;
+- PIN incorrecto limitado; supervisor sin permiso rechazado;
+- anulación parcial/total revierte stock, caja, pagos y kardex de manera atómica;
+- diferencia de precio/stock exige motivo y autorización según política;
+- venta original permanece inmutable; no se edita ni borra;
+- auditoría registra quién, cuándo, dispositivo, motivo, antes/después y autorización.
+
+### 11.6 LAN, continuidad y periféricos
+
+- dos POS se emparejan por QR/código; tercero no autorizado se rechaza;
+- revocar terminal, cambio de IP, router reiniciado, Ethernet/Wi-Fi y certificado no confiable;
+- servidor o Internet caído durante una operación; recuperación sin duplicados ni huérfanos;
+- p95 de búsquedas/agregar/cobrar menor a 300 ms en LAN objetivo;
+- scanner como teclado, impresora térmica, gaveta y balanza en hardware declarado;
+- backup cifrado/checksum y restore completo en otra máquina;
+- paquete diagnóstico sin secretos, rotación de logs y reinicio automático de servicios.
+
+### 11.7 Compra, portal y licencias
+
+- registro, correo no verificado, token vencido/usado, recuperación y MFA interna;
+- pedido PYME/Enterprise con precio/revisión congelados;
+- Mercado Pago aprobado, pendiente, rechazado, duplicado, webhook falso/desordenado, reembolso y contracargo;
+- transferencia con archivo inválido, fraude evidente, doble aprobación y conciliación;
+- un pago genera un solo entitlement/licencia/descarga;
+- IDOR: ningún cliente ve pedido, comprobante, licencia o artifact ajeno;
+- expiración/reemisión de descarga; hash/firma de artefacto inválidos;
+- fin de mantenimiento: versión adquirida funciona, release posterior se rechaza;
+- fin de Cloud: sincronización se pausa, el POS local sigue operando.
+
+## 12. Pruebas visuales y de usuario
+
+### 12.1 Automatización visual
+
+Capturas y comparaciones por Playwright en 1280×720, 1366×768, 1920×1080, tablet y móvil para:
+
+- login, dashboard, navbar y menú colapsado;
+- formularios y validaciones;
+- tablas largas, vacías y paginadas;
+- modales simples y apilados;
+- loading, error 400/401/403/409/422/500 y sin conexión;
+- POS, pago, boleta/impresión, caja, ventas, inventario, permisos y configuración;
+- zoom 200 %, teclado completo, foco visible, Escape, lector de pantalla y contraste WCAG AA.
+
+### 12.2 Prueba moderada
+
+Participantes: 3–5 por persona cuando sea posible —dueño/administrador, cajero, supervisor y bodeguero— sin guía paso a paso durante la ejecución.
+
+Métricas sugeridas:
+
+- 100 % de recorridos críticos completados;
+- al menos 90 % del resto sin ayuda;
+- primera instalación + primera venta en menos de 30 minutos con guía;
+- venta básica por usuario entrenado en menos de 45 segundos;
+- SUS igual o superior a 75;
+- cero dudas críticas sobre precio, pago, licencia, apertura/cierre y pérdida de datos.
+
+## 13. Seguridad y pruebas adversariales
+
+### Control plane y pagos
+
+- SQL injection, XSS, CSRF, SSRF, IDOR, brute force y session fixation;
+- upload de comprobantes: polyglot, MIME falso, path traversal, malware y tamaño excesivo;
+- webhook falsificado, replay, duplicado, fuera de orden y monto/moneda alterados;
+- rate limiting, secretos en logs, rotación de credenciales y caída del proveedor;
+- doble gasto lógico, carrera de fulfillment y descarga ajena.
+
+### Licencias e instalador
+
+- payload, firma, `kid`, algoritmo y tamaño manipulados;
+- tabla de plan/local DB/UI modificadas;
+- copia a otro equipo y replay/concurrencia de activación;
+- reloj hacia adelante/atrás, rollback de archivo y revocación antigua;
+- rotación de clave, refund/chargeback y recuperación por falla de hardware;
+- DLL/file hijacking, ACL de servicios, rutas con espacios, firma inválida y binario reemplazado;
+- control plane sin responder 72 horas: ventas locales continúan.
+
+## 14. Gates de calidad
+
+### Gate A — Base estable
+
+- trabajo local inventariado y PR reproducible;
+- `master` protegida y CI/escaneos obligatorios;
+- cero P0 en empleados, permisos, inventario, venta y caja;
+- todas las suites existentes ejecutadas por CI.
+
+### Gate B — Comercio y licencia sandbox
+
+- catálogo único aprobado;
+- cuenta verificada y portal seguro;
+- Mercado Pago y transferencia reconciliados;
+- fulfillment idempotente;
+- licencia/activación online y offline firmadas;
+- ninguna capacidad se obtiene manipulando UI/API/DB local.
+
+### Gate C — Release candidate local
+
+- instalador y manifests firmados con SBOM;
+- instalación/repair/upgrade/uninstall/restore certificados;
+- dos POS LAN, emparejamiento y revocación;
+- matriz plan × permiso × endpoint aprobada;
+- E2E funcional y visual sin defectos P0/P1.
+
+### Gate D — Beta cerrada
+
+- jornada simulada y p95 LAN dentro del presupuesto;
+- recuperación de fallos y backup/restore reales;
+- UAT de las cuatro personas aprobado;
+- documentación, soporte, incidentes y privacidad listos;
+- release `pilot` inmutable y trazable.
+
+### Gate E — Beta comercial
+
+- 2–5 comercios piloto y al menos dos semanas sin pérdida de datos;
+- pago → descarga → instalación → activación probado por clientes reales;
+- actualización y restore ejecutados durante piloto;
+- cero críticos/altos abiertos en compra, licencia, instalación, venta, caja, stock, permisos y recuperación;
+- decisión Go/No-Go firmada por Product Owner, Tech Lead y QA.
+
+## 15. Alcance de la primera Beta y posteriores
 
 ### Incluido
 
-- Instalador Blue-Cat Server para Windows 10/11 de 64 bits.
-- Uno a cinco terminales LAN mediante navegador/PWA.
-- Planes Single y Emprendedor completamente aplicados.
-- POS, productos, inventario, clientes, empleados básicos, ventas y cuadre.
-- Roles y permisos reales.
-- Productos por peso.
-- Importación/exportación XLS.
-- Backup local, restauración y actualización firmada.
-- Licencia online y activación offline asistida.
+- Blue-Cat PYME Standard local-first para Windows 10/11 x64;
+- servidor local y al menos dos terminales POS LAN;
+- productos unitarios y por peso, inventario, clientes, empleados, roles, POS, promociones, ventas y caja;
+- XLS/XLSX, plantilla/boleta/logo y periféricos declarados;
+- licencia perpetua, 12 meses de updates, activación online/offline;
+- backup, restore, repair, upgrade y rollback;
+- compra PYME por Mercado Pago y transferencia controlada si supera Gate E.
+
+### Enterprise durante la Beta
+
+- catálogo y enforcement existen;
+- venta asistida/cotizada;
+- capacidades Enterprise solo se anuncian como disponibles si pasan sus propios E2E;
+- despliegue y soporte controlados.
 
 ### Fuera de alcance inicial
 
-- Operación de un POS sin conexión al servidor local.
-- Sincronización bidireccional entre varios servidores/sucursales.
-- Aplicaciones móviles nativas.
-- Contabilidad completa, remuneraciones o ERP generalista.
-- Integraciones tributarias de múltiples países.
-- Marketplace de extensiones.
+- POS funcionando de forma autónoma cuando pierde el servidor LAN;
+- replicación directa de DB entre sucursales;
+- Cloud Sync productivo;
+- contabilidad/remuneraciones como ERP generalista;
+- app móvil nativa y marketplace de extensiones;
+- integraciones tributarias de múltiples países.
 
-## 7. Criterios de salida a Beta
+## 16. Backlog posterior: Cloud Sync
 
-- Cero defectos críticos o altos conocidos en venta, caja, stock, permisos y aislamiento.
-- Instalación y actualización exitosas en una máquina limpia.
-- Dos POS concurrentes probados durante una jornada simulada.
-- Restauración completa desde backup verificada.
-- Matriz de permisos automatizada y aprobada.
-- Licencias y límites de plan probados online/offline.
-- Manual de usuario, administrador, instalación y recuperación actualizados.
-- Inventario de terceros y licencias de redistribución aprobado.
-- Soporte piloto y procedimiento de incidentes disponibles.
-- Firma de código y canal de distribución definidos.
+Cloud Sync comienza después de Gate D como un programa separado de al menos cuatro sprints:
 
-## 8. Orden inmediato de ejecución
+1. modelo de eventos/outbox, identidad de nodo y cifrado;
+2. sincronización idempotente y resolución explícita de conflictos;
+3. multi-sucursal, monitoreo, reintentos, cuotas y facturación mensual;
+4. recuperación, seguridad, carga, privacidad y piloto multisucursal.
 
-1. Configurar remoto Git, integración continua y estrategia de versiones.
-2. Congelar alcance Beta y resolver duplicidad entre API activa y scripts legacy.
-3. Auditar esquema completo y aislamiento por cuenta.
-4. Crear pruebas de regresión para venta, stock, caja y permisos.
-5. Estabilizar POS y cuadre bajo concurrencia.
-6. Prototipar Blue-Cat Server como servicio Windows.
-7. Probar dos clientes LAN mediante PWA.
-8. Diseñar licencia firmada y tabla formal de planes.
-9. Implementar backup/restauración y actualizador.
-10. Ejecutar piloto controlado y cerrar defectos de salida.
+Nunca se debe abrir MariaDB a Internet ni copiar tablas en tiempo real sin protocolo de conflicto. Cada servidor local debe continuar vendiendo durante la interrupción y reconciliar eventos al regresar la conexión.
 
-## 9. Decisiones arquitectónicas que deben formalizarse
+## 17. Indicadores del programa
 
-- Windows como plataforma inicial del servidor.
-- MariaDB o MySQL y sus condiciones de redistribución.
-- Apache, Nginx, Caddy u otro servidor embebible.
-- PWA primero versus cliente de escritorio desde Beta.
-- Certificados TLS locales y proceso de confianza en clientes.
-- Proveedor y operación del servicio de licencias.
-- Política de actualizaciones incluida con licencia perpetua.
-- Soporte de hardware: impresoras, gavetas, balanzas y lectores.
-- Estrategia futura para múltiples sucursales y acceso remoto.
+| Dimensión | Indicador |
+|---|---|
+| Entrega | Lead time, historias aceptadas, defectos escapados y tasa de reapertura |
+| Calidad | P0/P1 abiertos, cobertura de recorridos críticos, flakes y regresiones visuales |
+| POS | p50/p95, ventas duplicadas, stock negativo no autorizado y descuadres |
+| Instalación | éxito limpio/upgrade/repair/restore por matriz Windows |
+| Comercio | conversión, pagos pendientes, conciliación, duplicidad y tiempo a fulfillment |
+| Licencia | activaciones exitosas, fallos legítimos, transferencias y disponibilidad del control plane |
+| UX | éxito por tarea, tiempo, errores, ayuda requerida y SUS |
+| Piloto | incidentes por tienda/día, tiempo de recuperación y pérdida de datos (objetivo: cero) |
 
-Estas decisiones deben registrarse antes de construir el instalador, porque afectan licencias de terceros, soporte, actualizaciones, seguridad y costo operativo.
+## 18. Próximos diez pasos concretos
+
+1. Aprobar este documento como roadmap canónico y nombrar Product Owner/QA.
+2. Resolver el catálogo único PYME/Enterprise/Cloud y sus límites en Sprint 0.
+3. Guardar, revisar y separar correctamente los cambios locales actuales.
+4. Proteger `master` y activar todos los controles de GitHub disponibles.
+5. Ejecutar Sprint 1: empleados, inventario decimal/transaccional, ventas inmutables y landing crítica.
+6. Crear un tablero con épicas, historias, responsables, dependencias y criterios de aceptación de los Sprints 0–12.
+7. Registrar ADR de identidad separada, Checkout Pro, licencias Ed25519 y entrega por entitlement.
+8. Preparar los cinco entornos y datos sintéticos reproducibles para QA.
+9. Automatizar primero los recorridos P0 de instalación, permisos, venta/caja, stock y compra/licencia.
+10. No habilitar pagos ni descargas públicas hasta superar Gate B; no declarar Beta hasta superar Gate D.
+
+## 19. Decisiones pendientes del Product Owner
+
+- precio y límites exactos por SKU;
+- módulos concretos que distinguen Enterprise;
+- países/monedas/impuestos soportados en Beta;
+- duración y nivel de soporte incluido;
+- devolución, contracargo, transferencia de licencia y reemplazo de hardware;
+- cantidad de activaciones y terminales POS;
+- periféricos oficialmente soportados;
+- política de conservación/borrado al desinstalar;
+- si transferencia bancaria estará disponible desde el primer día;
+- cuándo Enterprise deja de ser venta asistida;
+- compromiso de disponibilidad, retención y precio de Cloud Sync.
+
+Sin estas decisiones se puede construir infraestructura, pero no certificar que el producto entregado coincide con lo que se vende.

--- a/Blue-Cat/THIRD_PARTY_LICENSES.md
+++ b/Blue-Cat/THIRD_PARTY_LICENSES.md
@@ -7,6 +7,8 @@
 | MariaDB Community Server 11.4.12 | Base local | GPL-2.0-only; incluir `COPYING` y cumplir acceso/oferta de código fuente aplicable |
 | WinSW 2.12.0 x64 | Servicios Windows | MIT; incluir licencia y aviso de copyright |
 | Microsoft Visual C++ Redistributable 14.44.35211 x64 | Prerrequisito de PHP | Términos de redistribución de Microsoft Visual Studio 2022 |
+| Microsoft WebView2 SDK 1.0.4078.44 | API del cliente de escritorio | Microsoft Software License Terms; licencia y avisos incluidos junto al launcher |
+| Microsoft Edge WebView2 Runtime 150.0.4078.65 x64 | Motor web del cliente de escritorio | Términos de Microsoft Edge WebView2; instalador oficial firmado y verificado |
 | Inno Setup 6.7.3 | Herramienta de construcción; no se instala | Inno Setup License; el proveedor solicita adquirir licencia comercial antes de uso productivo/venta |
 | Font Awesome | Iconos web | Confirmar versión y licencia de los recursos distribuidos |
 | Navegador/PWA | Cliente | No se redistribuye navegador en la primera Beta |

--- a/Blue-Cat/assets/api/core.php
+++ b/Blue-Cat/assets/api/core.php
@@ -521,6 +521,13 @@ case 'plan_modulo_toggle':
 
 // ═══ SIDEBAR ═══
 case 'sidebar':
+    $setupMissing = [];
+    $catalogCount = (int)$conn->query("SELECT COUNT(*) total FROM modulo WHERE activo=1")->fetch_assoc()['total'];
+    if ($catalogCount === 0) $setupMissing[] = 'catalogo_modulos';
+    $stmtSetup = $conn->prepare("SELECT COUNT(*) total FROM suscripcion s JOIN empresa e ON e.id_empresa=s.id_empresa WHERE e.id_cuenta=? AND e.activo=1 AND s.estado='activa' AND (s.fecha_fin IS NULL OR s.fecha_fin>=CURDATE())");
+    $stmtSetup->bind_param('i', $accountId); $stmtSetup->execute();
+    if ((int)$stmtSetup->get_result()->fetch_assoc()['total'] === 0) $setupMissing[] = 'suscripcion';
+    $stmtSetup->close();
     $modulos = [[
         'codigo' => 'inicio',
         'nombre' => 'Inicio',
@@ -574,7 +581,10 @@ case 'sidebar':
     while ($f = $r->fetch_assoc()) {
         $permisos[$f['modulo']][] = $f['accion'];
     }
-    json(['modulos' => $modulos, 'permisos' => $permisos, 'usuario' => $uid]);
+    if (count($modulos) === 1 && !in_array('catalogo_modulos', $setupMissing, true) && !in_array('suscripcion', $setupMissing, true)) {
+        $setupMissing[] = 'permisos_modulos';
+    }
+    json(['modulos' => $modulos, 'permisos' => $permisos, 'usuario' => $uid, 'setup'=>['complete'=>count($setupMissing)===0,'missing'=>$setupMissing]]);
     break;
 
 // ═══ LICENCIA ═══

--- a/Blue-Cat/assets/css/blue-cat.css
+++ b/Blue-Cat/assets/css/blue-cat.css
@@ -7,6 +7,19 @@ body {
   min-height: 100vh;
 }
 
+.bc-setup-alert {
+  margin: 1rem auto;
+  max-width: 1100px;
+  padding: 1rem 1.25rem;
+  border: 1px solid #f3c46b;
+  border-radius: 12px;
+  background: #fff8e8;
+  color: #5f430d;
+  box-shadow: 0 6px 20px rgba(95, 67, 13, .08);
+}
+.bc-setup-alert strong { display: block; margin-bottom: .35rem; }
+.bc-setup-alert p { margin: 0; }
+
 /* Navbar */
 .navbar {
   background: linear-gradient(120deg, #0f172a 0%, #172554 100%);

--- a/Blue-Cat/assets/js/navbar.js
+++ b/Blue-Cat/assets/js/navbar.js
@@ -129,6 +129,25 @@
       });
     }
 
+    function showSetupState(setup, requestFailed) {
+      var current = document.querySelector('.bc-setup-alert');
+      if (current) current.remove();
+      if (!requestFailed && setup && setup.complete) return;
+      var host = document.querySelector('main') || document.querySelector('.container') || document.body;
+      var alert = document.createElement('section');
+      alert.className = 'bc-setup-alert';
+      var title = document.createElement('strong');
+      title.textContent = requestFailed ? 'No fue posible cargar los módulos' : 'Configuración inicial incompleta';
+      var detail = document.createElement('p');
+      var labels = { catalogo_modulos: 'catálogo de módulos', suscripcion: 'plan o suscripción', permisos_modulos: 'permisos del usuario' };
+      var missing = setup && Array.isArray(setup.missing) ? setup.missing.map(function (item) { return labels[item] || item; }) : [];
+      detail.textContent = requestFailed
+        ? 'El servidor no entregó la navegación. Abra Diagnóstico Blue-Cat desde el menú Inicio o ejecute Reparar.'
+        : 'Falta completar: ' + missing.join(', ') + '. Ejecute Reparar para finalizar la instalación.';
+      alert.appendChild(title); alert.appendChild(detail);
+      host.insertBefore(alert, host.firstChild);
+    }
+
     fetch('../assets/api/core.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -143,8 +162,10 @@
       };
       document.dispatchEvent(new CustomEvent('bluecat:permissions-ready', { detail: window.BlueCatPermissions }));
       render(data.modulos || []);
+      showSetupState(data.setup || null, false);
     }).catch(function () {
       render([{ codigo: 'inicio', nombre: 'Inicio', icono: 'fa-home', ruta: 'Inicio.html' }]);
+      showSetupState(null, true);
     });
   });
 }());

--- a/Blue-Cat/database/migrations/023_installed_module_catalog.sql
+++ b/Blue-Cat/database/migrations/023_installed_module_catalog.sql
@@ -1,0 +1,48 @@
+-- El catálogo comercial es dato maestro obligatorio, no dato de demostración.
+SET NAMES utf8mb4;
+START TRANSACTION;
+
+INSERT INTO modulo (codigo,nombre,icono,ruta,orden,activo) VALUES
+('pos','POS','fa-cash-register','pos.html',2,1),
+('inventario','Inventario','fa-box','inventario.html',3,1),
+('crm','Clientes CRM','fa-users','crm.html',4,1),
+('proveedores','Proveedores','fa-truck','proveedores.html',5,1),
+('facturas','Facturación','fa-file-invoice','facturas.html',6,1),
+('empleados','Empleados','fa-id-badge','empleados.html',7,1),
+('ventas','Ventas','fa-shopping-cart','ventas.html',8,1),
+('configuracion','Configuración','fa-cogs','configuracion.html',9,1)
+ON DUPLICATE KEY UPDATE nombre=VALUES(nombre),icono=VALUES(icono),ruta=VALUES(ruta),orden=VALUES(orden),activo=1;
+
+INSERT INTO plan (nombre,descripcion,precio,max_empresas,max_sucursales,max_usuarios,activo)
+SELECT 'Blue-Cat Beta Completa','Plan local de evaluación con todos los módulos instalados',0,1,4,10,1
+WHERE NOT EXISTS (SELECT 1 FROM plan WHERE nombre='Blue-Cat Beta Completa');
+
+INSERT IGNORE INTO plan_modulo(id_plan,id_modulo)
+SELECT p.id_plan,m.id_modulo
+FROM plan p CROSS JOIN modulo m
+WHERE p.nombre='Blue-Cat Beta Completa' AND p.activo=1 AND m.activo=1;
+
+-- Repara instalaciones de servidor creadas antes de esta migración.
+INSERT INTO suscripcion(id_empresa,id_plan,fecha_inicio,estado)
+SELECT e.id_empresa,p.id_plan,CURDATE(),'activa'
+FROM core_installation ci
+JOIN empresa e ON e.id_cuenta=ci.id_cuenta AND e.activo=1
+JOIN plan p ON p.nombre='Blue-Cat Beta Completa' AND p.activo=1
+WHERE ci.id_installation=1
+  AND NOT EXISTS (SELECT 1 FROM suscripcion s WHERE s.id_empresa=e.id_empresa AND s.estado='activa');
+
+-- El propietario de una instalación local es superadministrador de su cuenta.
+INSERT IGNORE INTO usuario_rol(id_user,id_rol)
+SELECT ci.id_user_admin,r.id_rol
+FROM core_installation ci
+JOIN rol r ON r.id_cuenta=ci.id_cuenta AND r.nombre='Administrador' AND r.activo=1
+WHERE ci.id_installation=1;
+
+INSERT IGNORE INTO rol_permiso(id_rol,id_permiso)
+SELECT r.id_rol,p.id_permiso
+FROM core_installation ci
+JOIN rol r ON r.id_cuenta=ci.id_cuenta AND r.nombre='Administrador' AND r.activo=1
+CROSS JOIN permiso p
+WHERE ci.id_installation=1;
+
+COMMIT;

--- a/Blue-Cat/docs/adr/0007-cliente-escritorio-webview2.md
+++ b/Blue-Cat/docs/adr/0007-cliente-escritorio-webview2.md
@@ -1,0 +1,38 @@
+# ADR-0007: cliente de escritorio Windows con WebView2
+
+- Estado: Aceptado para Beta
+- Fecha: 2026-07-17
+- Responsable: Pablo-Millones
+
+## Contexto
+
+Blue-Cat Server debe seguir siendo una aplicación web accesible desde varios POS, pero el equipo servidor necesita una experiencia de escritorio sin pestañas, barra de direcciones ni dependencia visible del navegador. El cliente debe abrir el servidor solo cuando base de datos, PHP y HTTPS estén disponibles, ofrecer modo kiosco y dejar una ruta técnica para impresión y periféricos.
+
+## Decisión
+
+Se distribuye `BlueCatDesktop.exe`, una ventana WPF ligera que hospeda Microsoft Edge WebView2. El SDK y el runtime Evergreen x64 están fijados por versión, URL y SHA-256 en `packaging/windows/runtime-lock.json`; el instalador incluye el runtime completo para funcionar sin Internet.
+
+El launcher:
+
+- comprueba e intenta iniciar `BlueCatDatabase`, `BlueCatPhp` y `BlueCatWeb` en orden;
+- espera el health check antes de mostrar la interfaz;
+- muestra un error comprensible y permite reintentar en lugar de quedar en blanco;
+- mantiene `https://localhost` fuera de la interfaz visible;
+- abre enlaces externos en el navegador del sistema y conserva rutas internas en la ventana;
+- inicia maximizado, recuerda tamaño y admite F11/Escape;
+- ofrece un acceso separado `--pos --fullscreen` para modo kiosco POS;
+- deshabilita DevTools y reduce menús del navegador en el POS.
+
+El cierre de la ventana no detiene los servicios: otros terminales LAN pueden estar vendiendo. El POS continúa siendo local-first respecto de Internet, pero no funciona si pierde conexión con Blue-Cat Server; el modo POS totalmente desconectado permanece fuera de la primera Beta.
+
+## Alternativas
+
+- **Electron:** buen ecosistema de periféricos, pero duplica Chromium y eleva memoria, tamaño y superficie de actualización.
+- **Tauri:** liviano, pero agrega Rust, otro pipeline y una integración Windows más compleja para el estado actual del producto.
+- **PWA/Edge app mode:** simple, pero ofrece menos control sobre arranque, errores, enlaces, servicios y comportamiento kiosco.
+
+WebView2 equilibra consumo, soporte de Windows 10/11 y mantenimiento. Lectores de código de barras que emulan teclado funcionan sin integración adicional. Impresoras térmicas, gavetas, balanzas e impresoras fiscales se incorporarán mediante un puente local firmado y permisos explícitos; no se habilita acceso genérico del contenido web al sistema operativo.
+
+## Seguridad y actualización
+
+El contenido cargado se limita al origen HTTPS local. DevTools se deshabilita en producción y ningún secreto se pasa por argumentos ni URL. El ejecutable, sus DLL y el runtime se actualizan exclusivamente mediante el instalador firmado. WebView2 conserva cookies y preferencias por usuario en `%LocalAppData%\Blue-Cat`.

--- a/Blue-Cat/packaging/windows/README.md
+++ b/Blue-Cat/packaging/windows/README.md
@@ -7,6 +7,7 @@ Este directorio contiene el contrato reproducible del instalador. Los binarios e
 - `runtime-lock.json`: versiones, procedencia, checksum y licencia.
 - `templates/`: configuraciones que el bootstrap renderiza con rutas absolutas.
 - `services/`: definiciones WinSW con dependencias y recuperación.
+- `desktop/`: fuente del launcher WPF/WebView2 independiente del navegador.
 - `scripts/`: descarga, validación, bootstrap y construcción de Windows.
 - `installer/`: fuente Inno Setup.
 
@@ -26,6 +27,8 @@ En Windows, con Inno Setup 6.7.3 instalado:
 .\scripts\Build-Installer.ps1
 ```
 
-El comando descarga y verifica los runtimes si faltan, crea un staging limpio y produce en `output/` el EXE, `SHA256SUMS.txt`, un SBOM SPDX 2.3 y metadatos de construcción. Una compilación local puede quedar sin firma para pruebas aisladas; no es publicable.
+El comando descarga y verifica los runtimes si faltan, compila `BlueCatDesktop.exe`, crea un staging limpio y produce en `output/` el EXE, `SHA256SUMS.txt`, un SBOM SPDX 2.3 y metadatos de construcción. Una compilación local puede quedar sin firma para pruebas aisladas; no es publicable.
+
+El instalador crea accesos en Escritorio e Inicio. `Blue-Cat` y `Blue-Cat POS` abren una ventana WebView2 propia en pantalla completa; `F11` alterna ese modo, `Esc` permite salir y `--windowed` fuerza una ventana maximizada. Ningún acceso abre la URL en el navegador predeterminado.
 
 El pipeline de release usa `-RequireSignature` y el certificado Authenticode protegido por GitHub. Si el certificado falta, está vencido o la firma no resulta válida, la publicación falla antes de crear el release.

--- a/Blue-Cat/packaging/windows/desktop/BlueCatDesktop.cs
+++ b/Blue-Cat/packaging/windows/desktop/BlueCatDesktop.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.ServiceProcess;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Microsoft.Win32;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace BlueCat.Desktop
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main(string[] args)
+        {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            bool posMode = HasArgument(args, "--pos");
+            bool diagnosticMode = HasArgument(args, "--diagnostic");
+            bool fullScreen = HasArgument(args, "--fullscreen") || (!diagnosticMode && !HasArgument(args, "--windowed"));
+            string target = diagnosticMode ? "https://localhost/public/diagnostico.html" : (posMode ? "https://localhost/public/pos.html" : "https://localhost/");
+            bool first;
+            using (var mutex = new System.Threading.Mutex(true, posMode ? "BlueCatDesktopPOS" : "BlueCatDesktop", out first))
+            {
+                if (!first) return;
+                var app = new Application { ShutdownMode = ShutdownMode.OnMainWindowClose };
+                app.Run(new BlueCatWindow(target, posMode, fullScreen));
+            }
+        }
+
+        private static bool HasArgument(string[] args, string value)
+        {
+            foreach (string arg in args) if (string.Equals(arg, value, StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+    }
+
+    internal sealed class BlueCatWindow : Window
+    {
+        private readonly string targetUrl;
+        private readonly bool posMode;
+        private readonly WebView2 webView;
+        private readonly Grid root;
+        private WindowStyle previousStyle = WindowStyle.SingleBorderWindow;
+        private WindowState previousState = WindowState.Maximized;
+        private bool isFullScreen;
+
+        internal BlueCatWindow(string target, bool isPos, bool startFullScreen)
+        {
+            targetUrl = target;
+            posMode = isPos;
+            Title = isPos ? "Blue-Cat POS" : "Blue-Cat";
+            MinWidth = 960;
+            MinHeight = 640;
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            Background = new SolidColorBrush(Color.FromRgb(238, 243, 249));
+            TrySetIcon();
+            RestoreWindow();
+
+            root = new Grid();
+            webView = new WebView2 { Visibility = Visibility.Collapsed };
+            root.Children.Add(webView);
+            Content = root;
+
+            PreviewKeyDown += OnPreviewKeyDown;
+            Closing += delegate { SaveWindow(); };
+            Loaded += async delegate
+            {
+                if (startFullScreen) SetFullScreen(true);
+                await InitializeAsync();
+            };
+        }
+
+        private async Task InitializeAsync()
+        {
+            ShowMessage("Iniciando Blue-Cat…", "Comprobando servicios locales.", false);
+            try
+            {
+                await EnsureServicesAsync();
+                ShowMessage("Iniciando Blue-Cat…", "Esperando que el servidor local esté disponible.", false);
+                if (!await WaitForBackendAsync())
+                {
+                    ShowMessage("Blue-Cat no pudo iniciar", "El servidor local no respondió. Revise si el puerto 443 está ocupado, el firewall o los servicios Blue-Cat.", true);
+                    return;
+                }
+
+                string userData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Blue-Cat", "WebView2");
+                Directory.CreateDirectory(userData);
+                CoreWebView2Environment environment = await CoreWebView2Environment.CreateAsync(null, userData);
+                await webView.EnsureCoreWebView2Async(environment);
+                webView.CoreWebView2.Settings.AreDevToolsEnabled = false;
+                webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
+                webView.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = true;
+                webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = !posMode;
+                webView.CoreWebView2.NewWindowRequested += OnNewWindowRequested;
+                webView.CoreWebView2.NavigationStarting += OnNavigationStarting;
+                webView.NavigationCompleted += OnNavigationCompleted;
+                root.Children.Clear();
+                root.Children.Add(webView);
+                webView.Visibility = Visibility.Visible;
+                webView.Source = new Uri(targetUrl);
+                webView.Focus();
+            }
+            catch (Exception error)
+            {
+                Log("No fue posible inicializar el cliente.", error);
+                ShowMessage("No fue posible abrir Blue-Cat", FriendlyError(error), true);
+            }
+        }
+
+        private static async Task EnsureServicesAsync()
+        {
+            string[] names = { "BlueCatDatabase", "BlueCatPhp", "BlueCatWeb" };
+            bool needsElevation = false;
+            foreach (string name in names)
+            {
+                using (var service = new ServiceController(name))
+                {
+                    try
+                    {
+                        service.Refresh();
+                        if (service.Status == ServiceControllerStatus.Stopped)
+                        {
+                            service.Start();
+                            service.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(30));
+                        }
+                    }
+                    catch { needsElevation = true; break; }
+                }
+            }
+            if (needsElevation)
+            {
+                var start = new ProcessStartInfo
+                {
+                    FileName = "powershell.exe",
+                    Arguments = "-NoProfile -ExecutionPolicy Bypass -Command \"Start-Service BlueCatDatabase; Start-Service BlueCatPhp; Start-Service BlueCatWeb\"",
+                    Verb = "runas",
+                    UseShellExecute = true,
+                    WindowStyle = ProcessWindowStyle.Hidden
+                };
+                using (Process process = Process.Start(start)) { process.WaitForExit(); }
+            }
+            await Task.Delay(250);
+        }
+
+        private static async Task<bool> WaitForBackendAsync()
+        {
+            DateTime deadline = DateTime.UtcNow.AddSeconds(45);
+            Exception lastError = null;
+            while (DateTime.UtcNow < deadline)
+            {
+                try
+                {
+                    var request = (HttpWebRequest)WebRequest.Create("https://localhost/assets/api/health.php");
+                    request.Method = "GET";
+                    request.Timeout = 2500;
+                    request.ReadWriteTimeout = 2500;
+                    Task<WebResponse> responseTask = request.GetResponseAsync();
+                    if (await Task.WhenAny(responseTask, Task.Delay(3000)) != responseTask)
+                    {
+                        request.Abort();
+                        throw new System.TimeoutException("El health check local superó 3 segundos.");
+                    }
+                    using (var response = (HttpWebResponse)await responseTask)
+                    using (var reader = new StreamReader(response.GetResponseStream()))
+                    {
+                        string body = await reader.ReadToEndAsync();
+                        if (response.StatusCode == HttpStatusCode.OK && body.Contains("\"status\":\"ok\"")) return true;
+                    }
+                }
+                catch (Exception error) { lastError = error; }
+                await Task.Delay(750);
+            }
+            Log("El backend local no respondió dentro del plazo.", lastError);
+            return false;
+        }
+
+        private static void Log(string message, Exception error)
+        {
+            try
+            {
+                string directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Blue-Cat", "logs");
+                Directory.CreateDirectory(directory);
+                string detail = error == null ? "" : " | " + error.GetType().Name + ": " + error.Message;
+                File.AppendAllText(Path.Combine(directory, "desktop.log"), DateTime.UtcNow.ToString("o") + " | " + message + detail + Environment.NewLine, System.Text.Encoding.UTF8);
+            }
+            catch { }
+        }
+
+        private void OnNewWindowRequested(object sender, CoreWebView2NewWindowRequestedEventArgs e)
+        {
+            e.Handled = true;
+            Uri uri;
+            if (Uri.TryCreate(e.Uri, UriKind.Absolute, out uri) && IsInternal(uri)) webView.Source = uri;
+            else if (Uri.TryCreate(e.Uri, UriKind.Absolute, out uri)) Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+        }
+
+        private void OnNavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            Uri uri;
+            if (!Uri.TryCreate(e.Uri, UriKind.Absolute, out uri) || IsInternal(uri)) return;
+            e.Cancel = true;
+            Process.Start(new ProcessStartInfo(uri.AbsoluteUri) { UseShellExecute = true });
+        }
+
+        private void OnNavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            if (!e.IsSuccess) ShowMessage("No se pudo cargar la pantalla", "El servidor respondió, pero la interfaz no pudo abrirse. Código: " + e.WebErrorStatus, true);
+        }
+
+        private static bool IsInternal(Uri uri)
+        {
+            return uri.Scheme == Uri.UriSchemeHttps && string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void ShowMessage(string title, string detail, bool retry)
+        {
+            root.Children.Clear();
+            var panel = new StackPanel { Width = 560, VerticalAlignment = VerticalAlignment.Center, HorizontalAlignment = HorizontalAlignment.Center };
+            panel.Children.Add(new TextBlock { Text = title, FontSize = 28, FontWeight = FontWeights.SemiBold, Foreground = new SolidColorBrush(Color.FromRgb(15, 34, 64)), TextAlignment = TextAlignment.Center, Margin = new Thickness(0, 0, 0, 14) });
+            panel.Children.Add(new TextBlock { Text = detail, FontSize = 16, Foreground = new SolidColorBrush(Color.FromRgb(65, 82, 110)), TextWrapping = TextWrapping.Wrap, TextAlignment = TextAlignment.Center, Margin = new Thickness(0, 0, 0, 22) });
+            if (retry)
+            {
+                var button = new Button { Content = "Reintentar", Width = 150, Height = 42, FontSize = 15, HorizontalAlignment = HorizontalAlignment.Center };
+                button.Click += async delegate { await InitializeAsync(); };
+                panel.Children.Add(button);
+            }
+            root.Children.Add(panel);
+        }
+
+        private static string FriendlyError(Exception error)
+        {
+            if (error.Message.IndexOf("WebView2", StringComparison.OrdinalIgnoreCase) >= 0)
+                return "Falta o está dañado Microsoft WebView2 Runtime. Ejecute Reparar desde Aplicaciones instaladas.";
+            if (error is System.ComponentModel.Win32Exception)
+                return "Windows no autorizó iniciar los servicios. Acepte la solicitud de administrador o ejecute Reparar.";
+            return "Revise los servicios Blue-Cat, el puerto 443 y el panel de diagnóstico. Detalle: " + error.Message;
+        }
+
+        private void OnPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.F11) { SetFullScreen(!isFullScreen); e.Handled = true; }
+            if (e.Key == Key.Escape && isFullScreen) { SetFullScreen(false); e.Handled = true; }
+        }
+
+        private void SetFullScreen(bool enabled)
+        {
+            if (enabled == isFullScreen) return;
+            if (enabled)
+            {
+                previousStyle = WindowStyle;
+                previousState = WindowState;
+                WindowStyle = WindowStyle.None;
+                WindowState = WindowState.Maximized;
+            }
+            else
+            {
+                WindowStyle = previousStyle;
+                WindowState = previousState;
+            }
+            isFullScreen = enabled;
+        }
+
+        private void RestoreWindow()
+        {
+            using (RegistryKey key = Registry.CurrentUser.OpenSubKey("Software\\Lifilab\\Blue-Cat"))
+            {
+                if (key != null)
+                {
+                    double value;
+                    if (double.TryParse(Convert.ToString(key.GetValue("Width")), out value) && value >= MinWidth) Width = value;
+                    if (double.TryParse(Convert.ToString(key.GetValue("Height")), out value) && value >= MinHeight) Height = value;
+                }
+            }
+            WindowState = WindowState.Maximized;
+        }
+
+        private void SaveWindow()
+        {
+            Rect bounds = RestoreBounds;
+            using (RegistryKey key = Registry.CurrentUser.CreateSubKey("Software\\Lifilab\\Blue-Cat"))
+            {
+                key.SetValue("Width", bounds.Width.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                key.SetValue("Height", bounds.Height.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            }
+        }
+
+        private void TrySetIcon()
+        {
+            try
+            {
+                using (System.Drawing.Icon icon = System.Drawing.Icon.ExtractAssociatedIcon(Process.GetCurrentProcess().MainModule.FileName))
+                {
+                    Icon = Imaging.CreateBitmapSourceFromHIcon(icon.Handle, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
+                }
+            }
+            catch { }
+        }
+    }
+}

--- a/Blue-Cat/packaging/windows/installer/BlueCatServer.iss
+++ b/Blue-Cat/packaging/windows/installer/BlueCatServer.iss
@@ -17,7 +17,8 @@ OutputBaseFilename=BlueCat-Server-Setup
 Compression=lzma2/ultra64
 SolidCompression=yes
 WizardStyle=modern
-UninstallDisplayIcon={app}\app\assets\images\logo.png
+SetupIconFile=..\build\desktop\BlueCat.ico
+UninstallDisplayIcon={app}\desktop\BlueCatDesktop.exe
 CloseApplications=yes
 RestartApplications=no
 RestartIfNeededByRun=yes
@@ -30,6 +31,8 @@ SignedUninstaller=yes
 [Files]
 Source: "..\build\stage\app\*"; DestDir: "{app}\app"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\build\stage\runtime\*"; DestDir: "{app}\runtime"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\build\stage\desktop\*"; DestDir: "{app}\desktop"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\build\stage\prerequisites\*"; DestDir: "{app}\prerequisites"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\build\stage\installer\*"; DestDir: "{app}\installer"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\build\stage\artifact-manifest.json"; DestDir: "{app}"; Flags: ignoreversion
 
@@ -37,13 +40,14 @@ Source: "..\build\stage\artifact-manifest.json"; DestDir: "{app}"; Flags: ignore
 Name: "{commonappdata}\Blue-Cat"; Permissions: admins-full system-full
 
 [Icons]
-Name: "{group}\Abrir Blue-Cat"; Filename: "https://localhost"; IconFilename: "{app}\app\assets\images\logo.png"
-Name: "{group}\Diagnóstico Blue-Cat"; Filename: "https://localhost/public/diagnostico.html"
+Name: "{autodesktop}\Blue-Cat"; Filename: "{app}\desktop\BlueCatDesktop.exe"; WorkingDir: "{app}\desktop"; IconFilename: "{app}\desktop\BlueCatDesktop.exe"
+Name: "{group}\Blue-Cat"; Filename: "{app}\desktop\BlueCatDesktop.exe"; WorkingDir: "{app}\desktop"
+Name: "{group}\Blue-Cat POS (pantalla completa)"; Filename: "{app}\desktop\BlueCatDesktop.exe"; Parameters: "--pos --fullscreen"; WorkingDir: "{app}\desktop"
+Name: "{group}\Diagnóstico Blue-Cat"; Filename: "{app}\desktop\BlueCatDesktop.exe"; Parameters: "--diagnostic"; WorkingDir: "{app}\desktop"
+Name: "{group}\Desinstalar Blue-Cat"; Filename: "{uninstallexe}"
 
 [Run]
-Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\installer\scripts\Install-Prerequisites.ps1"" -RuntimeRoot ""{app}\runtime"" -LockFile ""{app}\installer\runtime-lock.json"""; StatusMsg: "Instalando componentes de Microsoft..."; Flags: runhidden waituntilterminated
-Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\installer\scripts\Initialize-BlueCatServer.ps1"" -AppRoot ""{app}\app"" -RuntimeRoot ""{app}\runtime"" -DataRoot ""{commonappdata}\Blue-Cat"" -InstallationConfig ""{tmp}\bluecat-installation.json"""; StatusMsg: "Configurando Blue-Cat Server..."; Flags: runhidden waituntilterminated
-Filename: "https://localhost"; Description: "Abrir Blue-Cat Server"; Flags: postinstall shellexec skipifsilent nowait
+Filename: "{app}\desktop\BlueCatDesktop.exe"; Description: "Abrir Blue-Cat"; Flags: postinstall skipifsilent nowait
 
 [UninstallRun]
 Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\installer\scripts\Uninstall-BlueCatServices.ps1"" -RuntimeRoot ""{app}\runtime"" -DataRoot ""{commonappdata}\Blue-Cat"""; Flags: runhidden waituntilterminated; RunOnceId: "BlueCatServices"
@@ -51,6 +55,8 @@ Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile
 [Code]
 var
   CompanyPage, AdminPage, StorePage: TInputQueryWizardPage;
+  ExistingInstall: Boolean;
+  RestartRequired: Boolean;
 
 function JsonEscape(Value: String): String;
 begin
@@ -62,6 +68,7 @@ end;
 
 procedure InitializeWizard;
 begin
+  ExistingInstall := FileExists(ExpandConstant('{commonappdata}\Blue-Cat\install\state.json'));
   CompanyPage := CreateInputQueryPage(wpSelectDir, 'Datos del comercio', 'Empresa principal', 'Estos datos se usarán para crear la cuenta local.');
   CompanyPage.Add('Razón social:', False); CompanyPage.Add('Nombre comercial:', False); CompanyPage.Add('RUT:', False);
   CompanyPage.Add('Giro:', False); CompanyPage.Add('Dirección:', False); CompanyPage.Add('Ciudad:', False);
@@ -73,6 +80,11 @@ begin
   StorePage := CreateInputQueryPage(AdminPage.ID, 'Operación inicial', 'Sucursal, bodega y caja', 'Podrá modificar estos nombres después.');
   StorePage.Add('Sucursal:', False); StorePage.Add('Bodega:', False); StorePage.Add('Caja:', False);
   StorePage.Values[0] := 'Principal'; StorePage.Values[1] := 'Bodega Principal'; StorePage.Values[2] := 'Caja Principal';
+end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := ExistingInstall and ((PageID = CompanyPage.ID) or (PageID = AdminPage.ID) or (PageID = StorePage.ID));
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;
@@ -91,11 +103,32 @@ begin
   end;
 end;
 
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var StopScript, Parameters: String; ResultCode: Integer;
+begin
+  Result := '';
+  StopScript := ExpandConstant('{app}\installer\scripts\Stop-BlueCatServices.ps1');
+  if FileExists(StopScript) then
+    Parameters := '-NoProfile -ExecutionPolicy Bypass -File "' + StopScript + '"'
+  else begin
+    StopScript := ExpandConstant('{app}\installer\scripts\Uninstall-BlueCatServices.ps1');
+    Parameters := '-NoProfile -ExecutionPolicy Bypass -File "' + StopScript + '"' +
+      ' -RuntimeRoot "' + ExpandConstant('{app}\runtime') + '"' +
+      ' -DataRoot "' + ExpandConstant('{commonappdata}\Blue-Cat') + '"';
+  end;
+  if FileExists(StopScript) then begin
+    if (not Exec(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'), Parameters, '', SW_HIDE,
+      ewWaitUntilTerminated, ResultCode)) or (ResultCode <> 0) then
+      Result := 'No fue posible detener los servicios Blue-Cat para actualizar. Cierre Blue-Cat y vuelva a intentarlo.';
+  end;
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
-var Json: String;
+var Json, Parameters: String; ResultCode: Integer;
 begin
   if CurStep = ssInstall then begin
-    Json := '{' +
+    if ExistingInstall then Json := '{}'
+    else Json := '{' +
       '"company":{"legal_name":"' + JsonEscape(CompanyPage.Values[0]) + '","trade_name":"' + JsonEscape(CompanyPage.Values[1]) + '","tax_id":"' + JsonEscape(CompanyPage.Values[2]) + '","business_activity":"' + JsonEscape(CompanyPage.Values[3]) + '","address":"' + JsonEscape(CompanyPage.Values[4]) + '","city":"' + JsonEscape(CompanyPage.Values[5]) + '"},' +
       '"administrator":{"username":"' + JsonEscape(AdminPage.Values[0]) + '","full_name":"' + JsonEscape(AdminPage.Values[1]) + '","email":"' + JsonEscape(AdminPage.Values[2]) + '","password":"' + JsonEscape(AdminPage.Values[3]) + '"},' +
       '"currency":{"code":"CLP","name":"Peso chileno","symbol":"$","decimals":0},' +
@@ -103,8 +136,30 @@ begin
       '"branch":{"code":"SUC-001","name":"' + JsonEscape(StorePage.Values[0]) + '"},' +
       '"warehouse":{"code":"BOD-001","name":"' + JsonEscape(StorePage.Values[1]) + '"},' +
       '"cash_register":{"code":"CAJA-01","name":"' + JsonEscape(StorePage.Values[2]) + '"}' +
-    '}';
+      '}';
     SaveStringToFile(ExpandConstant('{tmp}\bluecat-installation.json'), Json, False);
   end;
+  if CurStep = ssPostInstall then begin
+    WizardForm.StatusLabel.Caption := 'Configurando y verificando Blue-Cat Server...';
+    Parameters := '-NoProfile -ExecutionPolicy Bypass -File "' +
+      ExpandConstant('{app}\installer\scripts\Invoke-BlueCatInstallation.ps1') + '"' +
+      ' -AppRoot "' + ExpandConstant('{app}\app') + '"' +
+      ' -RuntimeRoot "' + ExpandConstant('{app}\runtime') + '"' +
+      ' -DataRoot "' + ExpandConstant('{commonappdata}\Blue-Cat') + '"' +
+      ' -InstallationConfig "' + ExpandConstant('{tmp}\bluecat-installation.json') + '"' +
+      ' -PrerequisiteRoot "' + ExpandConstant('{app}\prerequisites') + '"' +
+      ' -LockFile "' + ExpandConstant('{app}\installer\runtime-lock.json') + '"';
+    if not Exec(ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'), Parameters, '', SW_HIDE,
+      ewWaitUntilTerminated, ResultCode) then
+      RaiseException('No fue posible iniciar la configuración de Blue-Cat.');
+    if (ResultCode <> 0) and (ResultCode <> 3010) then
+      RaiseException('Blue-Cat no pudo configurarse. Revise C:\ProgramData\Blue-Cat\logs\installer.log y ejecute Reparar.');
+    RestartRequired := ResultCode = 3010;
+  end;
   if CurStep = ssDone then DeleteFile(ExpandConstant('{tmp}\bluecat-installation.json'));
+end;
+
+function NeedRestart(): Boolean;
+begin
+  Result := RestartRequired;
 end;

--- a/Blue-Cat/packaging/windows/runtime-lock.json
+++ b/Blue-Cat/packaging/windows/runtime-lock.json
@@ -53,6 +53,27 @@
       "hash": "cc0ff0eb1dc3f5188ae6300faef32bf5beeba4bdd6e8e445a9184072096b713b",
       "license": "LicenseRef-Microsoft-Visual-Cpp-2022-Runtime",
       "license_url": "https://visualstudio.microsoft.com/license-terms/vs2022-cruntime/"
+    },
+    {
+      "id": "webview2-sdk",
+      "version": "1.0.4078.44",
+      "url": "https://api.nuget.org/v3-flatcontainer/microsoft.web.webview2/1.0.4078.44/microsoft.web.webview2.1.0.4078.44.nupkg",
+      "file": "microsoft.web.webview2.1.0.4078.44.nupkg",
+      "hash_algorithm": "SHA256",
+      "hash": "dc4d1d9168df26b830398303e50210b6e1729f6ce5a7ac69d2c766852f489962",
+      "license": "LicenseRef-Microsoft-WebView2-SDK",
+      "license_url": "https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4078.44/license"
+    },
+    {
+      "id": "webview2-runtime-installer",
+      "version": "150.0.4078.65",
+      "url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/6c36e6de-67d8-470e-a071-894d02cd99eb/MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+      "file": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+      "target_file": "MicrosoftEdgeWebView2RuntimeInstallerX64.exe",
+      "hash_algorithm": "SHA256",
+      "hash": "3a08103bed8a3d9aefdfc9ac10a672ea69605163f2dcb08d76cfd3e0444511c9",
+      "license": "LicenseRef-Microsoft-Edge-WebView2-Runtime",
+      "license_url": "https://www.microsoft.com/en-us/legal/terms-of-use"
     }
   ],
   "build_tools": [

--- a/Blue-Cat/packaging/windows/scripts/Build-DesktopLauncher.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Build-DesktopLauncher.ps1
@@ -1,0 +1,108 @@
+[CmdletBinding()]
+param(
+    [string]$PackageRoot = (Join-Path $PSScriptRoot '..'),
+    [string]$RuntimeRoot = (Join-Path $PSScriptRoot '..\build\runtime'),
+    [string]$OutputRoot = (Join-Path $PSScriptRoot '..\build\desktop')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$package = [IO.Path]::GetFullPath($PackageRoot)
+$runtime = [IO.Path]::GetFullPath($RuntimeRoot)
+$output = [IO.Path]::GetFullPath($OutputRoot)
+$sdk = Join-Path $runtime 'webview2-sdk'
+$source = Join-Path $package 'desktop\BlueCatDesktop.cs'
+$core = Join-Path $sdk 'lib\net462\Microsoft.Web.WebView2.Core.dll'
+$wpf = Join-Path $sdk 'lib\net462\Microsoft.Web.WebView2.Wpf.dll'
+$loader = Join-Path $sdk 'runtimes\win-x64\native\WebView2Loader.dll'
+$logo = Join-Path $package '..\..\assets\img\Blue-Cat_logo-removebg.png'
+foreach ($required in @($source,$core,$wpf,$loader,$logo)) {
+    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) { throw "Falta $required para construir el launcher." }
+}
+
+if (Test-Path -LiteralPath $output) {
+    $resolved = [IO.Path]::GetFullPath($output)
+    if (-not $resolved.StartsWith($package + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Se rechazo limpiar una ruta fuera del paquete: $resolved"
+    }
+    [IO.Directory]::Delete($resolved, $true)
+}
+New-Item -ItemType Directory -Path $output | Out-Null
+
+Add-Type -AssemblyName System.Drawing
+$iconPath = Join-Path $output 'BlueCat.ico'
+$bitmap = [Drawing.Bitmap]::FromFile($logo)
+try {
+    $iconSizes = @(16,24,32,48,64,128,256)
+    $pngImages = @()
+    foreach ($size in $iconSizes) {
+        $canvas = [Drawing.Bitmap]::new($size,$size,[Drawing.Imaging.PixelFormat]::Format32bppArgb)
+        try {
+            $graphics = [Drawing.Graphics]::FromImage($canvas)
+            try {
+                $graphics.Clear([Drawing.Color]::Transparent)
+                $graphics.CompositingMode = [Drawing.Drawing2D.CompositingMode]::SourceCopy
+                $graphics.CompositingQuality = [Drawing.Drawing2D.CompositingQuality]::HighQuality
+                $graphics.InterpolationMode = [Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+                $graphics.PixelOffsetMode = [Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+                $padding = [Math]::Max(1,[int][Math]::Round($size * 0.025))
+                $graphics.DrawImage($bitmap,$padding,$padding,$size-(2*$padding),$size-(2*$padding))
+            } finally { $graphics.Dispose() }
+            $memory = [IO.MemoryStream]::new()
+            try {
+                $canvas.Save($memory,[Drawing.Imaging.ImageFormat]::Png)
+                $pngImages += ,$memory.ToArray()
+            } finally { $memory.Dispose() }
+        } finally { $canvas.Dispose() }
+    }
+
+    $stream = [IO.File]::Create($iconPath)
+    $writer = [IO.BinaryWriter]::new($stream)
+    try {
+        $writer.Write([UInt16]0); $writer.Write([UInt16]1); $writer.Write([UInt16]$iconSizes.Count)
+        $offset = 6 + (16 * $iconSizes.Count)
+        for ($index=0; $index -lt $iconSizes.Count; $index++) {
+            $size = $iconSizes[$index]
+            $writer.Write([byte]$(if ($size -eq 256) { 0 } else { $size }))
+            $writer.Write([byte]$(if ($size -eq 256) { 0 } else { $size }))
+            $writer.Write([byte]0); $writer.Write([byte]0)
+            $writer.Write([UInt16]1); $writer.Write([UInt16]32)
+            $writer.Write([UInt32]$pngImages[$index].Length); $writer.Write([UInt32]$offset)
+            $offset += $pngImages[$index].Length
+        }
+        foreach ($imageBytes in $pngImages) { $writer.Write($imageBytes) }
+    } finally { $writer.Dispose(); $stream.Dispose() }
+} finally { $bitmap.Dispose() }
+
+$assembly = Join-Path $output 'BlueCatDesktop.exe'
+Add-Type -AssemblyName System.Core,System.Drawing,System.ServiceProcess,System.Xaml,WindowsBase,PresentationCore,PresentationFramework
+$references = @(
+    [Uri].Assembly.Location,
+    [Linq.Enumerable].Assembly.Location,
+    [Drawing.Icon].Assembly.Location,
+    [System.ServiceProcess.ServiceController].Assembly.Location,
+    [System.Xaml.XamlReader].Assembly.Location,
+    [System.Windows.DependencyObject].Assembly.Location,
+    [System.Windows.Media.Brush].Assembly.Location,
+    [System.Windows.Window].Assembly.Location,
+    $core,$wpf
+)
+$compiler = [Microsoft.CSharp.CSharpCodeProvider]::new()
+$parameters = [CodeDom.Compiler.CompilerParameters]::new()
+$parameters.GenerateExecutable = $true
+$parameters.GenerateInMemory = $false
+$parameters.OutputAssembly = $assembly
+$parameters.CompilerOptions = "/target:winexe /optimize /win32icon:`"$iconPath`""
+foreach ($reference in $references) { [void]$parameters.ReferencedAssemblies.Add($reference) }
+$result = $compiler.CompileAssemblyFromSource($parameters, (Get-Content -LiteralPath $source -Raw -Encoding UTF8))
+$compiler.Dispose()
+if ($result.Errors.HasErrors) {
+    $messages = @($result.Errors | ForEach-Object { "$($_.FileName):$($_.Line): $($_.ErrorText)" })
+    throw "El launcher no compiló:`n$($messages -join "`n")"
+}
+
+Copy-Item -LiteralPath $core,$wpf,$loader -Destination $output -Force
+Copy-Item -LiteralPath (Join-Path $sdk 'LICENSE.txt'),(Join-Path $sdk 'NOTICE.txt') -Destination $output -Force
+if (-not (Test-Path -LiteralPath $assembly)) { throw 'No se genero BlueCatDesktop.exe.' }
+Write-Host "Launcher WebView2 preparado en $output"

--- a/Blue-Cat/packaging/windows/scripts/Build-Installer.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Build-Installer.ps1
@@ -34,12 +34,15 @@ function Find-SignTool {
 
 $package = [IO.Path]::GetFullPath($PackageRoot)
 $runtime = Join-Path $package 'build\runtime'
+$desktop = Join-Path $package 'build\desktop'
 $stage = Join-Path $package 'build\stage'
 $output = Join-Path $package 'output'
 $lockPath = Join-Path $package 'runtime-lock.json'
 $requiredRuntime = @(
     (Join-Path $runtime 'php\php.exe'),
-    (Join-Path $runtime 'vc-redist-x64\vc_redist.x64.exe')
+    (Join-Path $runtime 'vc-redist-x64\vc_redist.x64.exe'),
+    (Join-Path $runtime 'webview2-sdk\lib\net462\Microsoft.Web.WebView2.Wpf.dll'),
+    (Join-Path $runtime 'webview2-runtime-installer\MicrosoftEdgeWebView2RuntimeInstallerX64.exe')
 )
 
 if (-not (Test-Path -LiteralPath $InnoCompiler)) { throw "No se encontro Inno Setup 6.7.3: $InnoCompiler" }
@@ -55,13 +58,13 @@ if (@($requiredRuntime | Where-Object { -not (Test-Path -LiteralPath $_) }).Coun
         -LockFile $lockPath `
         -CachePath (Join-Path $package 'cache') `
         -OutputPath $runtime
-    if ($LASTEXITCODE -ne 0) { throw 'No fue posible preparar los runtimes.' }
 }
+
+& (Join-Path $PSScriptRoot 'Build-DesktopLauncher.ps1') -PackageRoot $package -RuntimeRoot $runtime -OutputRoot $desktop
 
 Remove-PackageDirectory -Path $stage -Root $package
 Remove-PackageDirectory -Path $output -Root $package
-& (Join-Path $PSScriptRoot 'New-InstallerStage.ps1') -RuntimeRoot $runtime -StageRoot $stage
-if ($LASTEXITCODE -ne 0) { throw 'No fue posible preparar el staging.' }
+& (Join-Path $PSScriptRoot 'New-InstallerStage.ps1') -RuntimeRoot $runtime -DesktopRoot $desktop -StageRoot $stage
 
 & $InnoCompiler /Qp (Join-Path $package 'installer\BlueCatServer.iss')
 if ($LASTEXITCODE -ne 0) { throw 'La compilacion del instalador fallo.' }

--- a/Blue-Cat/packaging/windows/scripts/Fetch-Runtimes.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Fetch-Runtimes.ps1
@@ -40,7 +40,14 @@ foreach ($component in $lock.components) {
 
     $destination = Join-Path $OutputPath $component.id
     New-Item -ItemType Directory -Path $destination -Force | Out-Null
-    if ($component.file.EndsWith('.zip', [StringComparison]::OrdinalIgnoreCase)) {
+    if ($component.file.EndsWith('.nupkg', [StringComparison]::OrdinalIgnoreCase)) {
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $extractRoot = Join-Path $OutputPath ('.extract-' + [Guid]::NewGuid().ToString('N'))
+        [IO.Compression.ZipFile]::ExtractToDirectory($archive, $extractRoot)
+        Copy-Item -Path (Join-Path $extractRoot '*') -Destination $destination -Recurse -Force
+        if (-not ([IO.Path]::GetFullPath($extractRoot)).StartsWith([IO.Path]::GetFullPath($OutputPath), [StringComparison]::OrdinalIgnoreCase)) { throw 'Ruta temporal fuera del build.' }
+        Remove-Item -LiteralPath $extractRoot -Recurse -Force
+    } elseif ($component.file.EndsWith('.zip', [StringComparison]::OrdinalIgnoreCase)) {
         if ($component.id -eq 'mariadb') {
             $extractRoot = Join-Path $OutputPath ('.extract-' + [Guid]::NewGuid().ToString('N'))
             New-Item -ItemType Directory -Path $extractRoot | Out-Null

--- a/Blue-Cat/packaging/windows/scripts/Initialize-BlueCatServer.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Initialize-BlueCatServer.ps1
@@ -54,6 +54,16 @@ function Unprotect-MachineSecret([string]$Source) {
 function Assert-Executable([string]$Path) {
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { throw "Falta el ejecutable $Path." }
 }
+function Wait-ServiceAbsent([string]$Name, [int]$TimeoutSeconds = 30) {
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        $service = Get-Service -Name $Name -ErrorAction SilentlyContinue
+        if (-not $service) { return }
+        $service.Dispose()
+        Start-Sleep -Milliseconds 500
+    } while ([DateTime]::UtcNow -lt $deadline)
+    throw "El servicio anterior $Name quedó pendiente de eliminación. Reinicie Windows y ejecute Reparar."
+}
 
 $packageRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
 $app = [IO.Path]::GetFullPath($AppRoot)
@@ -81,6 +91,19 @@ $mariaClientExe = Join-Path $mariaBin 'mariadb.exe'
 $mariaAdminExe = Join-Path $mariaBin 'mariadb-admin.exe'
 $winswExe = Join-Path $runtime 'winsw\WinSW-x64.exe'
 foreach ($executable in @($caddyExe,$phpExe,$phpCgiExe,$mariadbdExe,$installDbExe,$mariaClientExe,$mariaAdminExe,$winswExe)) { Assert-Executable $executable }
+
+if (-not $SkipServices) {
+    $conflicts = @()
+    Get-NetTCPConnection -State Listen -LocalPort 443 -ErrorAction SilentlyContinue | ForEach-Object {
+        $process = Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue
+        if ($process -and $process.ProcessName -ne 'caddy') {
+            $conflicts += "$($process.ProcessName) (PID $($process.Id))"
+        }
+    }
+    if ($conflicts.Count -gt 0) {
+        throw "El puerto HTTPS 443 esta ocupado por $($conflicts -join ', '). Cierre Laragon/Apache u otro servidor y ejecute Reparar."
+    }
+}
 
 if ($SiteAddresses.Count -eq 0) {
     $SiteAddresses = @('localhost', [Net.Dns]::GetHostName())
@@ -157,7 +180,12 @@ DB_PASSWORD=$appPassword
     Protect-MachineSecret $rootPassword (Join-Path $paths.Config 'database-admin.secret')
     Remove-Item -LiteralPath $sqlFile -Force
 }
-elseif ($SkipServices) {
+else {
+    $databaseService = Get-Service -Name 'BlueCatDatabase' -ErrorAction SilentlyContinue
+    $mustStartTemporaryDatabase = $SkipServices -or -not $databaseService -or $databaseService.Status -ne 'Running'
+    if ($databaseService) { $databaseService.Dispose() }
+}
+if ($databaseInitialized -and $mustStartTemporaryDatabase) {
     $rootPassword = Unprotect-MachineSecret (Join-Path $paths.Config 'database-admin.secret')
     Write-Utf8NoBom $rootClientConfig "[client]`nhost=127.0.0.1`nport=3307`nuser=root`npassword=$rootPassword`n"
     $temporaryDatabase = Start-Process -FilePath $mariadbdExe -ArgumentList @("--defaults-file=$mariaIni",'--console') -WindowStyle Hidden -PassThru
@@ -191,10 +219,31 @@ if (-not $SkipServices) {
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent(); $principal = [Security.Principal.WindowsPrincipal]::new($identity)
     if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'La instalación de servicios requiere elevación de administrador.' }
     & icacls.exe $data '/inheritance:r' '/grant:r' '*S-1-5-18:(OI)(CI)F' '*S-1-5-32-544:(OI)(CI)F' '*S-1-5-19:(OI)(CI)M' | Out-Null
-    foreach ($serviceName in @('BlueCatDatabase','BlueCatPhp','BlueCatWeb')) {
-        if (-not (Get-Service -Name $serviceName -ErrorAction SilentlyContinue)) { & (Join-Path $paths.Services ($serviceName + '.exe')) install }
+    $serviceNames = @('BlueCatDatabase','BlueCatPhp','BlueCatWeb')
+    foreach ($serviceName in @('BlueCatWeb','BlueCatPhp','BlueCatDatabase')) {
+        $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+        if ($service -and $service.Status -ne 'Stopped') {
+            Stop-Service -Name $serviceName -Force
+            $service.WaitForStatus([ServiceProcess.ServiceControllerStatus]::Stopped,[TimeSpan]::FromSeconds(30))
+        }
+        if ($service) { $service.Dispose() }
     }
-    foreach ($serviceName in @('BlueCatDatabase','BlueCatPhp','BlueCatWeb')) { Start-Service -Name $serviceName }
+    foreach ($serviceName in $serviceNames) {
+        $wrapper = Join-Path $paths.Services ($serviceName + '.exe')
+        $existingService = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+        if ($existingService) {
+            $existingService.Dispose()
+            & $wrapper uninstall
+            if ($LASTEXITCODE -ne 0) { throw "No fue posible retirar el servicio anterior $serviceName." }
+            Wait-ServiceAbsent $serviceName 30
+        }
+        & $wrapper install
+        if ($LASTEXITCODE -ne 0) { throw "No fue posible registrar el servicio $serviceName." }
+    }
+    foreach ($serviceName in $serviceNames) {
+        Start-Service -Name $serviceName
+        (Get-Service -Name $serviceName).WaitForStatus([ServiceProcess.ServiceControllerStatus]::Running,[TimeSpan]::FromSeconds(45))
+    }
     $rootCertificate = Join-Path $paths.Caddy 'pki\authorities\local\root.crt'
     $certificateDeadline = [DateTime]::UtcNow.AddSeconds(45)
     while (-not (Test-Path -LiteralPath $rootCertificate) -and [DateTime]::UtcNow -lt $certificateDeadline) { Start-Sleep -Milliseconds 500 }
@@ -204,6 +253,15 @@ if (-not $SkipServices) {
     if (-not (Get-NetFirewallRule -DisplayName 'Blue-Cat Server HTTPS' -ErrorAction SilentlyContinue)) {
         New-NetFirewallRule -DisplayName 'Blue-Cat Server HTTPS' -Direction Inbound -Action Allow -Protocol TCP -LocalPort 443 -Profile Private | Out-Null
     }
+    $healthDeadline = [DateTime]::UtcNow.AddSeconds(45)
+    $healthy = $false
+    do {
+        try {
+            $health = Invoke-RestMethod -UseBasicParsing -Uri 'https://localhost/assets/api/health.php' -TimeoutSec 5
+            $healthy = $health.status -eq 'ok' -and $health.database -eq $true -and $health.setup -eq $true
+        } catch { Start-Sleep -Milliseconds 750 }
+    } while (-not $healthy -and [DateTime]::UtcNow -lt $healthDeadline)
+    if (-not $healthy) { throw 'Los servicios iniciaron, pero el health check de Blue-Cat no quedo operativo.' }
 }
 
 $state = [ordered]@{schema=1;configured_at=[DateTime]::UtcNow.ToString('o');app_root=$app;data_root=$data;site_addresses=$SiteAddresses;services_installed=(-not $SkipServices)}

--- a/Blue-Cat/packaging/windows/scripts/Install-Prerequisites.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Install-Prerequisites.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$true)][string]$RuntimeRoot,
+    [Parameter(Mandatory=$true)][string]$PrerequisiteRoot,
     [Parameter(Mandatory=$true)][string]$LockFile,
     [switch]$VerifyOnly
 )
@@ -8,26 +8,39 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$runtime = [IO.Path]::GetFullPath($RuntimeRoot)
+$prerequisites = [IO.Path]::GetFullPath($PrerequisiteRoot)
 $lock = Get-Content -LiteralPath $LockFile -Raw | ConvertFrom-Json
-$component = $lock.components | Where-Object id -eq 'vc-redist-x64' | Select-Object -First 1
-if (-not $component) { throw 'Falta vc-redist-x64 en runtime-lock.json.' }
-$installer = Join-Path $runtime 'vc-redist-x64\vc_redist.x64.exe'
-if (-not (Test-Path -LiteralPath $installer)) { throw 'Falta Microsoft Visual C++ Runtime en el paquete.' }
-$actual = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash.ToLowerInvariant()
-if ($actual -ne $component.hash.ToLowerInvariant()) { throw 'Checksum invalido para Microsoft Visual C++ Runtime.' }
-$signature = Get-AuthenticodeSignature -LiteralPath $installer
-if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Subject -notlike '*Microsoft Corporation*') {
-    throw "Firma Microsoft invalida para el prerrequisito: $($signature.Status)."
+
+function Assert-MicrosoftPrerequisite([string]$ComponentId, [string]$FileName) {
+    $component = $lock.components | Where-Object id -eq $ComponentId | Select-Object -First 1
+    if (-not $component) { throw "Falta $ComponentId en runtime-lock.json." }
+    $installer = Join-Path $prerequisites $FileName
+    if (-not (Test-Path -LiteralPath $installer)) { throw "Falta $FileName en el paquete." }
+    $actual = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $component.hash.ToLowerInvariant()) { throw "Checksum invalido para $ComponentId." }
+    $signature = Get-AuthenticodeSignature -LiteralPath $installer
+    if ($signature.Status -ne 'Valid' -or $signature.SignerCertificate.Subject -notlike '*Microsoft Corporation*') {
+        throw "Firma Microsoft invalida para ${ComponentId}: $($signature.Status)."
+    }
+    return $installer
 }
+
+$vcInstaller = Assert-MicrosoftPrerequisite 'vc-redist-x64' 'vc_redist.x64.exe'
+$webViewInstaller = Assert-MicrosoftPrerequisite 'webview2-runtime-installer' 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe'
 if ($VerifyOnly) {
-    Write-Host 'Microsoft Visual C++ Runtime verificado.'
+    Write-Host 'Prerrequisitos Microsoft verificados.'
     exit 0
 }
 
-$process = Start-Process -FilePath $installer -ArgumentList '/install','/quiet','/norestart' -Wait -PassThru
+$process = Start-Process -FilePath $vcInstaller -ArgumentList '/install','/quiet','/norestart' -Wait -PassThru
 if ($process.ExitCode -notin @(0, 1638, 3010)) {
     throw "Microsoft Visual C++ Runtime fallo con codigo $($process.ExitCode)."
 }
-if ($process.ExitCode -eq 3010) { exit 3010 }
+$restartRequired = $process.ExitCode -eq 3010
+
+$process = Start-Process -FilePath $webViewInstaller -ArgumentList '/silent','/install' -Wait -PassThru
+if ($process.ExitCode -notin @(0, 1638, 3010)) {
+    throw "Microsoft WebView2 Runtime fallo con codigo $($process.ExitCode)."
+}
+if ($restartRequired -or $process.ExitCode -eq 3010) { exit 3010 }
 exit 0

--- a/Blue-Cat/packaging/windows/scripts/Invoke-BlueCatInstallation.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Invoke-BlueCatInstallation.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$AppRoot,
+    [Parameter(Mandatory=$true)][string]$RuntimeRoot,
+    [Parameter(Mandatory=$true)][string]$DataRoot,
+    [Parameter(Mandatory=$true)][string]$InstallationConfig,
+    [Parameter(Mandatory=$true)][string]$PrerequisiteRoot,
+    [Parameter(Mandatory=$true)][string]$LockFile
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$logDirectory = Join-Path ([IO.Path]::GetFullPath($DataRoot)) 'logs'
+New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+$logFile = Join-Path $logDirectory 'installer.log'
+$restartRequired = $false
+$exitCode = 0
+
+Start-Transcript -LiteralPath $logFile -Force | Out-Null
+try {
+    $powerShell = Join-Path $PSHOME 'powershell.exe'
+    $prerequisiteOutput = Join-Path $logDirectory 'prerequisites-output.log'
+    $prerequisiteError = Join-Path $logDirectory 'prerequisites-error.log'
+    $prerequisiteProcess = Start-Process -FilePath $powerShell -WindowStyle Hidden -Wait -PassThru -ArgumentList @(
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ('"' + (Join-Path $PSScriptRoot 'Install-Prerequisites.ps1') + '"'),
+        '-PrerequisiteRoot', ('"' + $PrerequisiteRoot + '"'), '-LockFile', ('"' + $LockFile + '"')
+    ) -RedirectStandardOutput $prerequisiteOutput -RedirectStandardError $prerequisiteError
+    Get-Content -LiteralPath $prerequisiteOutput -ErrorAction SilentlyContinue | Write-Host
+    Get-Content -LiteralPath $prerequisiteError -ErrorAction SilentlyContinue | Write-Host
+    if ($prerequisiteProcess.ExitCode -notin @(0, 3010)) { throw "La instalación de prerrequisitos falló con código $($prerequisiteProcess.ExitCode)." }
+    $restartRequired = $prerequisiteProcess.ExitCode -eq 3010
+
+    $initializeOutput = Join-Path $logDirectory 'initialize-output.log'
+    $initializeError = Join-Path $logDirectory 'initialize-error.log'
+    $initializeProcess = Start-Process -FilePath $powerShell -WindowStyle Hidden -Wait -PassThru -ArgumentList @(
+        '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ('"' + (Join-Path $PSScriptRoot 'Initialize-BlueCatServer.ps1') + '"'),
+        '-AppRoot', ('"' + $AppRoot + '"'), '-RuntimeRoot', ('"' + $RuntimeRoot + '"'),
+        '-DataRoot', ('"' + $DataRoot + '"'), '-InstallationConfig', ('"' + $InstallationConfig + '"')
+    ) -RedirectStandardOutput $initializeOutput -RedirectStandardError $initializeError
+    Get-Content -LiteralPath $initializeOutput -ErrorAction SilentlyContinue | Write-Host
+    Get-Content -LiteralPath $initializeError -ErrorAction SilentlyContinue | Write-Host
+    if ($initializeProcess.ExitCode -ne 0) { throw "La configuración de Blue-Cat falló con código $($initializeProcess.ExitCode)." }
+
+    Write-Host 'Instalación de Blue-Cat completada y verificada.'
+    if ($restartRequired) { $exitCode = 3010 }
+} catch {
+    $exitCode = 1
+    Write-Error ("Instalación de Blue-Cat interrumpida: " + $_.Exception.Message)
+} finally {
+    Stop-Transcript | Out-Null
+}
+
+exit $exitCode

--- a/Blue-Cat/packaging/windows/scripts/New-InstallerStage.ps1
+++ b/Blue-Cat/packaging/windows/scripts/New-InstallerStage.ps1
@@ -2,6 +2,7 @@
 param(
     [string]$SourceRoot = (Join-Path $PSScriptRoot '..\..\..'),
     [string]$RuntimeRoot = (Join-Path $PSScriptRoot '..\build\runtime'),
+    [string]$DesktopRoot = (Join-Path $PSScriptRoot '..\build\desktop'),
     [string]$StageRoot = (Join-Path $PSScriptRoot '..\build\stage')
 )
 
@@ -9,16 +10,20 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 $source = [IO.Path]::GetFullPath($SourceRoot)
 $runtime = [IO.Path]::GetFullPath($RuntimeRoot)
+$desktop = [IO.Path]::GetFullPath($DesktopRoot)
 $stage = [IO.Path]::GetFullPath($StageRoot)
 if (Test-Path -LiteralPath $stage) { throw "El staging ya existe: $stage. Use un directorio vacío para evitar artefactos obsoletos." }
-foreach ($required in @('caddy\caddy.exe','php\php.exe','mariadb\bin\mariadbd.exe','winsw\WinSW-x64.exe','vc-redist-x64\vc_redist.x64.exe','runtime-lock.json')) {
+foreach ($required in @('caddy\caddy.exe','php\php.exe','mariadb\bin\mariadbd.exe','winsw\WinSW-x64.exe','vc-redist-x64\vc_redist.x64.exe','webview2-runtime-installer\MicrosoftEdgeWebView2RuntimeInstallerX64.exe','runtime-lock.json')) {
     if (-not (Test-Path -LiteralPath (Join-Path $runtime $required))) { throw "Runtime incompleto: falta $required." }
 }
+if (-not (Test-Path -LiteralPath (Join-Path $desktop 'BlueCatDesktop.exe'))) { throw 'Falta construir el launcher de escritorio.' }
 
 $appStage = Join-Path $stage 'app'
 $runtimeStage = Join-Path $stage 'runtime'
 $installerStage = Join-Path $stage 'installer'
-New-Item -ItemType Directory -Path $appStage,$runtimeStage,$installerStage -Force | Out-Null
+$desktopStage = Join-Path $stage 'desktop'
+$prerequisiteStage = Join-Path $stage 'prerequisites'
+New-Item -ItemType Directory -Path $appStage,$runtimeStage,$installerStage,$desktopStage,$prerequisiteStage -Force | Out-Null
 
 $excludedDirectories = @('.git','backups','cache','node_modules','vendor','packaging','storage\backups')
 $excludedFiles = @('.env','.env.local','.env.production','*.log','*.tmp','*.bak')
@@ -26,7 +31,13 @@ $arguments = @($source,$appStage,'/E','/R:2','/W:1','/NFL','/NDL','/NJH','/NJS',
     ($excludedDirectories | ForEach-Object { Join-Path $source $_ }) + @('/XF') + $excludedFiles
 & robocopy.exe @arguments | Out-Null
 if ($LASTEXITCODE -ge 8) { throw "Robocopy de aplicación falló con código $LASTEXITCODE." }
-Copy-Item -Path (Join-Path $runtime '*') -Destination $runtimeStage -Recurse -Force
+foreach ($component in @('caddy','php','mariadb','winsw')) {
+    Copy-Item -LiteralPath (Join-Path $runtime $component) -Destination $runtimeStage -Recurse -Force
+}
+Copy-Item -LiteralPath (Join-Path $runtime 'runtime-lock.json') -Destination $runtimeStage -Force
+Copy-Item -Path (Join-Path $desktop '*') -Destination $desktopStage -Recurse -Force
+Copy-Item -LiteralPath (Join-Path $runtime 'vc-redist-x64\vc_redist.x64.exe') -Destination $prerequisiteStage -Force
+Copy-Item -LiteralPath (Join-Path $runtime 'webview2-runtime-installer\MicrosoftEdgeWebView2RuntimeInstallerX64.exe') -Destination $prerequisiteStage -Force
 Copy-Item -LiteralPath (Join-Path $PSScriptRoot '..\templates') -Destination $installerStage -Recurse -Force
 Copy-Item -LiteralPath (Join-Path $PSScriptRoot '..\services') -Destination $installerStage -Recurse -Force
 Copy-Item -LiteralPath $PSScriptRoot -Destination $installerStage -Recurse -Force

--- a/Blue-Cat/packaging/windows/scripts/Stop-BlueCatServices.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Stop-BlueCatServices.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+foreach ($serviceName in @('BlueCatWeb','BlueCatPhp','BlueCatDatabase')) {
+    $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+    if (-not $service) { continue }
+    try {
+        if ($service.Status -ne [ServiceProcess.ServiceControllerStatus]::Stopped) {
+            Stop-Service -Name $serviceName -Force
+            $service.WaitForStatus([ServiceProcess.ServiceControllerStatus]::Stopped,[TimeSpan]::FromSeconds(45))
+        }
+    } finally {
+        $service.Dispose()
+    }
+}
+
+Write-Host 'Servicios Blue-Cat detenidos para actualización.'

--- a/Blue-Cat/packaging/windows/scripts/Test-Initialize-BlueCatServer.ps1
+++ b/Blue-Cat/packaging/windows/scripts/Test-Initialize-BlueCatServer.ps1
@@ -18,6 +18,7 @@ try {
 
     & (Join-Path $PSScriptRoot 'Initialize-BlueCatServer.ps1') -AppRoot $appRoot -RuntimeRoot $runtimeRoot -DataRoot (Join-Path $testRoot 'ProgramData') -InstallationConfig $configFile -SiteAddresses @('localhost') -SkipServices
     if ($LASTEXITCODE -ne 0) { throw 'La primera inicialización devolvió error.' }
+    [IO.File]::WriteAllText($configFile, '{}', [Text.UTF8Encoding]::new($false))
     & (Join-Path $PSScriptRoot 'Initialize-BlueCatServer.ps1') -AppRoot $appRoot -RuntimeRoot $runtimeRoot -DataRoot (Join-Path $testRoot 'ProgramData') -InstallationConfig $configFile -SiteAddresses @('localhost') -SkipServices
     if ($LASTEXITCODE -ne 0) { throw 'La reparación devolvió error.' }
 
@@ -30,7 +31,8 @@ try {
     & (Join-Path $runtimeRoot 'caddy\caddy.exe') validate --config (Join-Path $dataRoot 'config\Caddyfile') --adapter caddyfile
     if ($LASTEXITCODE -ne 0) { throw 'Caddy rechazó la configuración renderizada.' }
     foreach ($serviceName in @('BlueCatDatabase','BlueCatPhp','BlueCatWeb')) {
-        [xml](Get-Content -LiteralPath (Join-Path $dataRoot "install\services\$serviceName.xml") -Raw) | Out-Null
+        [xml]$serviceXml = Get-Content -LiteralPath (Join-Path $dataRoot "install\services\$serviceName.xml") -Raw
+        if ($serviceXml.service.serviceaccount.user -ne 'LocalService') { throw "$serviceName no usa la cuenta restringida LocalService." }
     }
     $state = Get-Content -LiteralPath (Join-Path $dataRoot 'install\state.json') -Raw | ConvertFrom-Json
     if ($state.services_installed -ne $false -or $state.site_addresses -notcontains 'localhost') { throw 'El estado de instalación es inválido.' }

--- a/Blue-Cat/packaging/windows/services/BlueCatDatabase.xml.template
+++ b/Blue-Cat/packaging/windows/services/BlueCatDatabase.xml.template
@@ -6,7 +6,7 @@
   <arguments>--defaults-file="@@MARIADB_INI@@" --console</arguments>
   <startmode>Automatic</startmode>
   <delayedAutoStart>true</delayedAutoStart>
-  <serviceaccount><username>NT AUTHORITY\LocalService</username></serviceaccount>
+  <serviceaccount><domain>NT AUTHORITY</domain><user>LocalService</user></serviceaccount>
   <stoptimeout>60sec</stoptimeout>
   <onfailure action="restart" delay="10 sec" />
   <onfailure action="restart" delay="30 sec" />

--- a/Blue-Cat/packaging/windows/services/BlueCatPhp.xml.template
+++ b/Blue-Cat/packaging/windows/services/BlueCatPhp.xml.template
@@ -7,7 +7,7 @@
   <depend>BlueCatDatabase</depend>
   <startmode>Automatic</startmode>
   <delayedAutoStart>true</delayedAutoStart>
-  <serviceaccount><username>NT AUTHORITY\LocalService</username></serviceaccount>
+  <serviceaccount><domain>NT AUTHORITY</domain><user>LocalService</user></serviceaccount>
   <env name="BLUECAT_ENV_FILE" value="@@ENV_FILE@@" />
   <stoptimeout>30sec</stoptimeout>
   <onfailure action="restart" delay="5 sec" />

--- a/Blue-Cat/packaging/windows/services/BlueCatWeb.xml.template
+++ b/Blue-Cat/packaging/windows/services/BlueCatWeb.xml.template
@@ -7,7 +7,7 @@
   <depend>BlueCatPhp</depend>
   <startmode>Automatic</startmode>
   <delayedAutoStart>true</delayedAutoStart>
-  <serviceaccount><username>NT AUTHORITY\LocalService</username></serviceaccount>
+  <serviceaccount><domain>NT AUTHORITY</domain><user>LocalService</user></serviceaccount>
   <stoptimeout>30sec</stoptimeout>
   <onfailure action="restart" delay="5 sec" />
   <onfailure action="restart" delay="15 sec" />

--- a/Blue-Cat/scripts/bootstrap-installation.php
+++ b/Blue-Cat/scripts/bootstrap-installation.php
@@ -42,6 +42,54 @@ function installCode(array $source, string $key, int $max): string
     return $value;
 }
 
+function provisionInstalledEdition(mysqli $db, int $accountId, int $adminId): void
+{
+    provisionTenantRoles($db, $accountId);
+
+    $role = 'Administrador';
+    $stmt = $db->prepare("INSERT IGNORE INTO usuario_rol(id_user,id_rol) SELECT ?,id_rol FROM rol WHERE id_cuenta=? AND nombre=? AND es_plantilla=0 AND activo=1 LIMIT 1");
+    $stmt->bind_param('iis', $adminId, $accountId, $role);
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $db->prepare("INSERT IGNORE INTO rol_permiso(id_rol,id_permiso) SELECT r.id_rol,p.id_permiso FROM rol r CROSS JOIN permiso p WHERE r.id_cuenta=? AND r.nombre='Administrador' AND r.activo=1");
+    $stmt->bind_param('i', $accountId);
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $db->prepare("INSERT IGNORE INTO plan_modulo(id_plan,id_modulo) SELECT p.id_plan,m.id_modulo FROM plan p CROSS JOIN modulo m WHERE p.nombre='Blue-Cat Beta Completa' AND p.activo=1 AND m.activo=1");
+    $stmt->execute();
+    $stmt->close();
+
+    $stmt = $db->prepare("INSERT INTO suscripcion(id_empresa,id_plan,fecha_inicio,estado) SELECT e.id_empresa,p.id_plan,CURDATE(),'activa' FROM empresa e JOIN plan p ON p.nombre='Blue-Cat Beta Completa' AND p.activo=1 WHERE e.id_cuenta=? AND e.activo=1 AND NOT EXISTS (SELECT 1 FROM suscripcion s WHERE s.id_empresa=e.id_empresa AND s.estado='activa')");
+    $stmt->bind_param('i', $accountId);
+    $stmt->execute();
+    $stmt->close();
+}
+
+// Una reparación no necesita volver a leer ni solicitar datos comerciales o
+// credenciales. Migra y recompone únicamente catálogos/autorizaciones.
+$db = getDB();
+try {
+    $migration = $db->prepare("SELECT 1 FROM schema_migration WHERE version='023_installed_module_catalog.sql' LIMIT 1");
+    $migration->execute();
+    $ready = (bool)$migration->get_result()->fetch_row();
+    $migration->close();
+    if (!$ready) throw new RuntimeException('Ejecute todas las migraciones antes del bootstrap.');
+    $existing = $db->query('SELECT installation_id,id_cuenta,id_user_admin,setup_completed FROM core_installation WHERE id_installation=1')->fetch_assoc();
+    if ($existing) {
+        $db->begin_transaction();
+        provisionInstalledEdition($db, (int)$existing['id_cuenta'], (int)$existing['id_user_admin']);
+        $db->commit();
+        echo json_encode(['ok'=>true,'status'=>'already-configured','installation_id'=>$existing['installation_id'],'id_cuenta'=>(int)$existing['id_cuenta']], JSON_UNESCAPED_UNICODE) . PHP_EOL;
+        exit(0);
+    }
+} catch (Throwable $error) {
+    try { $db->rollback(); } catch (Throwable) {}
+    fwrite(STDERR, 'Reparación cancelada: ' . $error->getMessage() . "\n");
+    exit(1);
+}
+
 $raw = file_get_contents($configFile);
 $config = $raw !== false ? json_decode($raw, true) : null;
 if (!is_array($config)) {
@@ -92,9 +140,8 @@ try {
     exit(2);
 }
 
-$db = getDB();
 try {
-    $migration = $db->prepare("SELECT 1 FROM schema_migration WHERE version='022_installation_state.sql' LIMIT 1");
+    $migration = $db->prepare("SELECT 1 FROM schema_migration WHERE version='023_installed_module_catalog.sql' LIMIT 1");
     $migration->execute();
     $ready = (bool)$migration->get_result()->fetch_row();
     $migration->close();
@@ -102,6 +149,9 @@ try {
 
     $existing = $db->query('SELECT installation_id,id_cuenta,id_user_admin,setup_completed FROM core_installation WHERE id_installation=1')->fetch_assoc();
     if ($existing) {
+        $db->begin_transaction();
+        provisionInstalledEdition($db, (int)$existing['id_cuenta'], (int)$existing['id_user_admin']);
+        $db->commit();
         echo json_encode(['ok'=>true,'status'=>'already-configured','installation_id'=>$existing['installation_id'],'id_cuenta'=>(int)$existing['id_cuenta']], JSON_UNESCAPED_UNICODE) . PHP_EOL;
         exit(0);
     }
@@ -119,11 +169,6 @@ try {
     $stmt->bind_param('ii', $adminId, $accountId); $stmt->execute(); $stmt->close();
 
     provisionTenantRoles($db, $accountId);
-    $role = 'Administrador';
-    $stmt = $db->prepare("INSERT INTO usuario_rol(id_user,id_rol) SELECT ?,id_rol FROM rol WHERE id_cuenta=? AND nombre=? AND es_plantilla=0 LIMIT 1");
-    $stmt->bind_param('iis', $adminId, $accountId, $role); $stmt->execute();
-    if ($stmt->affected_rows !== 1) throw new RuntimeException('No fue posible asignar el rol Administrador.');
-    $stmt->close();
 
     $stmt = $db->prepare("INSERT INTO empresa(id_cuenta,razon_social,nombre_comercial,rut,giro,direccion,ciudad,moneda_base,activo) VALUES (?,?,?,?,?,?,?,?,1)");
     $stmt->bind_param('isssssss', $accountId, $legalName, $tradeName, $taxId, $activity, $address, $city, $currencyCode); $stmt->execute(); $companyId = (int)$db->insert_id; $stmt->close();
@@ -146,6 +191,7 @@ try {
     $version = trim((string)@file_get_contents($root . DIRECTORY_SEPARATOR . 'VERSION')) ?: 'development';
     $stmt = $db->prepare('INSERT INTO core_installation(id_installation,id_cuenta,id_user_admin,installation_id,installed_version,setup_completed) VALUES (1,?,?,?,?,1)');
     $stmt->bind_param('iiss', $accountId, $adminId, $installationId, $version); $stmt->execute(); $stmt->close();
+    provisionInstalledEdition($db, $accountId, $adminId);
     $db->commit();
 
     echo json_encode(['ok'=>true,'status'=>'configured','installation_id'=>$installationId,'id_cuenta'=>$accountId,'id_empresa'=>$companyId,'id_sucursal'=>$branchId,'id_bodega'=>$warehouseId,'id_caja_fisica'=>$cashId], JSON_UNESCAPED_UNICODE) . PHP_EOL;

--- a/Blue-Cat/scripts/test-installation-bootstrap.php
+++ b/Blue-Cat/scripts/test-installation-bootstrap.php
@@ -58,6 +58,7 @@ try {
     $db = new mysqli($host, $user, $password, $database, $port);
     $checks = [
         'cuenta'=>1,'usuario'=>1,'empresa'=>1,'sucursal'=>1,'bodega'=>1,'pos_caja_fisica'=>1,'core_installation'=>1,
+        'modulo'=>8,'plan'=>1,'plan_modulo'=>8,'suscripcion'=>1,
     ];
     foreach ($checks as $table=>$expected) {
         $count = (int)$db->query("SELECT COUNT(*) total FROM `{$table}`")->fetch_assoc()['total'];
@@ -67,6 +68,8 @@ try {
     if (!$row || !password_verify('Bootstrap9Segura', $row['password'])) throw new RuntimeException('La contraseña inicial no quedó hasheada correctamente.');
     $adminRole = (int)$db->query("SELECT COUNT(*) total FROM usuario_rol ur JOIN rol r ON r.id_rol=ur.id_rol WHERE r.nombre='Administrador' AND r.id_cuenta IS NOT NULL")->fetch_assoc()['total'];
     if ($adminRole !== 1) throw new RuntimeException('El administrador no recibió su rol local.');
+    $permissionCounts = $db->query("SELECT COUNT(DISTINCT rp.id_permiso) assigned,(SELECT COUNT(*) FROM permiso) available FROM usuario_rol ur JOIN rol r ON r.id_rol=ur.id_rol JOIN rol_permiso rp ON rp.id_rol=r.id_rol WHERE ur.id_user=(SELECT id_user FROM usuario WHERE nombre='adminbeta') AND r.nombre='Administrador'")->fetch_assoc();
+    if ((int)$permissionCounts['assigned'] !== (int)$permissionCounts['available']) throw new RuntimeException('El superadministrador no recibió todos los permisos disponibles.');
     $db->close();
     $db = null;
 
@@ -75,6 +78,8 @@ try {
     if ($code !== 0 || ($result['status'] ?? '') !== 'already-configured') throw new RuntimeException("La reparación idempotente falló: {$err} {$out}");
     echo "PASS instalación inicial crea cuenta, administrador, empresa, sucursal, bodega y caja\n";
     echo "PASS contraseña elegida se almacena con hash fuerte\n";
+    echo "PASS catálogo, plan, suscripción y módulos quedan habilitados\n";
+    echo "PASS superadministrador recibe todos los permisos\n";
     echo "PASS segundo bootstrap es idempotente\n";
 } finally {
     if (isset($db) && $db instanceof mysqli) $db->close();

--- a/Blue-Cat/scripts/verify-windows-package.php
+++ b/Blue-Cat/scripts/verify-windows-package.php
@@ -9,7 +9,7 @@ $lock = is_file($lockFile) ? json_decode((string)file_get_contents($lockFile), t
 if (!is_array($lock) || ($lock['schema'] ?? 0) !== 1 || ($lock['platform'] ?? '') !== 'windows-x64') {
     $errors[] = 'runtime-lock.json inválido.';
 } else {
-    $required = ['caddy','php','mariadb','winsw','vc-redist-x64'];
+    $required = ['caddy','php','mariadb','winsw','vc-redist-x64','webview2-sdk','webview2-runtime-installer'];
     $found = [];
     foreach (($lock['components'] ?? []) as $component) {
         $id = (string)($component['id'] ?? '');
@@ -36,9 +36,13 @@ $requiredFiles = [
     'scripts/Test-Initialize-BlueCatServer.ps1'=>['reparación idempotente','bluecat-server-test-'],
     'scripts/New-InstallerStage.ps1'=>['artifact-manifest.json','Get-FileHash'],
     'scripts/Build-Installer.ps1'=>['RequireSignature','BlueCat-Server.spdx.json','SHA256SUMS.txt','signtool.exe'],
-    'scripts/Install-Prerequisites.ps1'=>['Get-AuthenticodeSignature','Microsoft Corporation','3010'],
+    'scripts/Build-DesktopLauncher.ps1'=>['BlueCatDesktop.exe','Microsoft.Web.WebView2.Wpf.dll','win32icon','Drawing.Color]::Transparent','256'],
+    'scripts/Install-Prerequisites.ps1'=>['Get-AuthenticodeSignature','Microsoft Corporation','webview2-runtime-installer','3010'],
+    'scripts/Invoke-BlueCatInstallation.ps1'=>['installer.log','Initialize-BlueCatServer.ps1','RedirectStandardError'],
+    'scripts/Stop-BlueCatServices.ps1'=>['BlueCatWeb','Stop-Service','Dispose'],
     'scripts/Uninstall-BlueCatServices.ps1'=>['Datos conservados','BlueCatDatabase'],
-    'installer/BlueCatServer.iss'=>['bluecat-installation.json','PrivilegesRequired=admin','SignedUninstaller','Install-Prerequisites.ps1'],
+    'desktop/BlueCatDesktop.cs'=>['CoreWebView2Environment','--fullscreen','EnsureServicesAsync','WaitForBackendAsync','SecurityProtocolType.Tls12','desktop.log'],
+    'installer/BlueCatServer.iss'=>['bluecat-installation.json','PrivilegesRequired=admin','SignedUninstaller','Invoke-BlueCatInstallation.ps1','{autodesktop}\\Blue-Cat','BlueCatDesktop.exe','SetupIconFile'],
 ];
 foreach ($requiredFiles as $relative=>$needles) {
     $contents = @file_get_contents($package . '/' . $relative);


### PR DESCRIPTION
## Qué cambia

- completa el launcher WebView2 y las verificaciones del instalador pendientes después de la PR #13
- reemplaza el roadmap anterior por el plan ágil canónico hasta Beta comercial
- documenta comercio, identidad, Mercado Pago, licencias firmadas, LAN, QA, gates y piloto

## Motivo

Dejar una línea de entrega verificable para iniciar Sprint 1 sin mezclar los cambios locales aún no revisados.

## Validación

- `git diff --cached --check` sin errores al confirmar el roadmap
- los cambios locales fuera de estos commits no forman parte de la PR