### PR TITLE
feat: prepare isolated commercial staging

### DIFF
--- a/.github/workflows/staging-images.yml
+++ b/.github/workflows/staging-images.yml
@@ -1,0 +1,91 @@
+name: Publish staging images
+
+on:
+  workflow_dispatch:
+    inputs:
+      site_url:
+        description: HTTPS origin assigned to staging
+        required: true
+        type: string
+      image_tag:
+        description: Immutable deployment label
+        required: true
+        default: staging
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: staging-image-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release inputs
+        shell: bash
+        env:
+          SITE_URL: ${{ inputs.site_url }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          [[ "$SITE_URL" =~ ^https://[^/]+/?$ ]] || { echo "site_url must be an HTTPS origin"; exit 1; }
+          [[ "$IMAGE_TAG" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]] || { echo "image_tag is invalid"; exit 1; }
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish portal runtime
+        uses: docker/build-push-action@v6
+        with:
+          context: blue-cat-landing
+          target: runner
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/blue-cat-portal:${{ inputs.image_tag }}
+            ghcr.io/${{ github.repository_owner }}/blue-cat-portal:${{ github.sha }}
+          build-args: |
+            NEXT_PUBLIC_SITE_URL=${{ inputs.site_url }}
+            NEXT_PUBLIC_COMMERCIAL_EMAIL=${{ vars.STAGING_COMMERCIAL_EMAIL }}
+            PUBLIC_INDEXING_ENABLED=false
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=staging-runner
+          cache-to: type=gha,mode=max,scope=staging-runner
+
+      - name: Publish migration image
+        uses: docker/build-push-action@v6
+        with:
+          context: blue-cat-landing
+          target: migrator
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/blue-cat-portal:${{ inputs.image_tag }}-migrator
+            ghcr.io/${{ github.repository_owner }}/blue-cat-portal:${{ github.sha }}-migrator
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=staging-migrator
+          cache-to: type=gha,mode=max,scope=staging-migrator
+
+      - name: Record immutable deployment reference
+        shell: bash
+        run: |
+          {
+            echo "### Staging images"
+            echo "- Runtime: ghcr.io/${{ github.repository_owner }}/blue-cat-portal:${{ github.sha }}"
+            echo "- Migrator: ghcr.io/${{ github.repository_owner }}/blue-cat-portal:${{ github.sha }}-migrator"
+            echo "- Public scope: blue-cat-landing only"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/staging-readiness.yml
+++ b/.github/workflows/staging-readiness.yml
@@ -1,0 +1,97 @@
+name: Staging readiness
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "blue-cat-landing/**"
+      - ".github/workflows/staging-readiness.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: staging-readiness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: blue-cat-landing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: blue-cat-landing/package-lock.json
+
+      - run: npm ci
+
+      - name: Generate ephemeral staging configuration
+        shell: bash
+        run: |
+          identity_key="$(openssl rand -base64 32 | tr -d '\n')"
+          identity_pepper="$(openssl rand -hex 32)"
+          outbox_token="$(openssl rand -hex 32)"
+          purchase_token="$(openssl rand -hex 32)"
+          database_password="$(openssl rand -hex 24)"
+          resend_key="re_$(openssl rand -hex 24)"
+          for value in "$identity_key" "$identity_pepper" "$outbox_token" "$purchase_token" "$database_password" "$resend_key"; do
+            echo "::add-mask::$value"
+          done
+          {
+            echo "APP_ENV=staging"
+            echo "NODE_ENV=production"
+            echo "NEXT_PUBLIC_SITE_URL=https://staging.blue-cat.test"
+            echo "STAGING_HOST=staging.blue-cat.test"
+            echo "DEPLOYMENT_COMMIT=0000000000000000000000000000000000000001"
+            echo "PORTAL_IMAGE_TAG=0000000000000000000000000000000000000001"
+            echo "DATABASE_URL=mysql://portal:$database_password@database:3306/blue_cat_portal"
+            echo "DATABASE_CREATE_ALLOWED=false"
+            echo "IDENTITY_DATA_KEY=$identity_key"
+            echo "IDENTITY_HASH_PEPPER=$identity_pepper"
+            echo "OUTBOX_WORKER_TOKEN=$outbox_token"
+            echo "PURCHASE_TOKEN_SECRET=$purchase_token"
+            echo "EMAIL_PROVIDER=resend"
+            echo "EMAIL_FROM=Blue Cat Staging <cuentas@blue-cat.test>"
+            echo "RESEND_API_KEY=$resend_key"
+            echo "CURRENT_TERMS_VERSION=terms-staging-ci"
+            echo "CURRENT_PRIVACY_VERSION=privacy-staging-ci"
+            echo "CURRENT_MARKETING_CONSENT_VERSION=marketing-staging-ci"
+            echo "COMMERCE_ENABLED=false"
+            echo "LEGAL_STATUS=draft"
+            echo "PUBLIC_INDEXING_ENABLED=false"
+          } >> "$GITHUB_ENV"
+
+      - run: npm run staging:verify-config
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build portal runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: blue-cat-landing
+          target: runner
+          push: false
+          build-args: |
+            NEXT_PUBLIC_SITE_URL=https://staging.blue-cat.test
+            NEXT_PUBLIC_COMMERCIAL_EMAIL=ventas@blue-cat.test
+            PUBLIC_INDEXING_ENABLED=false
+          cache-from: type=gha,scope=staging-runner
+          cache-to: type=gha,mode=max,scope=staging-runner
+
+      - name: Build migration image
+        uses: docker/build-push-action@v6
+        with:
+          context: blue-cat-landing
+          target: migrator
+          push: false
+          cache-from: type=gha,scope=staging-migrator
+          cache-to: type=gha,mode=max,scope=staging-migrator

--- a/.github/workflows/tenant-isolation.yml
+++ b/.github/workflows/tenant-isolation.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           printf '%s\n' \
             'APP_ENV=test' \
+            'APP_TIMEZONE=America/Santiago' \
             'DB_HOST=127.0.0.1' \
             'DB_PORT=3306' \
             'DB_NAME=bluecat_test' \

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 Thumbs.db
 .idea/
 .vscode/
+
+# Credenciales y datos del despliegue comercial.
+/blue-cat-landing/deploy/staging/.env.staging
+/blue-cat-landing/deploy/staging/backups/

--- a/Blue-Cat/assets/api/_db.php
+++ b/Blue-Cat/assets/api/_db.php
@@ -1,9 +1,13 @@
 <?php
-date_default_timezone_set('America/Santiago');
 
 require_once __DIR__ . '/env_loader.php';
 $configuredEnv = getenv('BLUECAT_ENV_FILE');
 loadEnv($configuredEnv !== false && $configuredEnv !== '' ? $configuredEnv : dirname(__DIR__, 2) . '/.env');
+$appTimezone = getenv('APP_TIMEZONE') ?: 'America/Santiago';
+if (!in_array($appTimezone, timezone_identifiers_list(), true)) {
+    $appTimezone = 'America/Santiago';
+}
+date_default_timezone_set($appTimezone);
 require_once __DIR__ . '/_security.php';
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -44,6 +48,11 @@ function getDB(): mysqli {
             exit;
         }
         $db->set_charset('utf8mb4');
+        $databaseOffset = (new DateTimeImmutable('now'))->format('P');
+        $escapedOffset = $db->real_escape_string($databaseOffset);
+        if (!$db->query("SET time_zone='{$escapedOffset}'")) {
+            throw new RuntimeException('No se pudo sincronizar la zona horaria de la base de datos.');
+        }
     }
     return $db;
 }

--- a/Blue-Cat/scripts/test-dashboard-signed-notes.php
+++ b/Blue-Cat/scripts/test-dashboard-signed-notes.php
@@ -176,6 +176,8 @@ if (getenv('APP_ENV') !== 'test' || DB_NAME === 'erp') {
 $db = getDB();
 $tenant = $foreignTenant = [];
 try {
+    $databaseToday = (string)($db->query("SELECT DATE_FORMAT(CURDATE(), '%Y-%m-%d') AS today")->fetch_assoc()['today'] ?? '');
+    expectDashboard($databaseToday === date('Y-m-d'), 'PHP y MySQL comparten el mismo dia operativo');
     $tenant = createDashboardTenant($db, 'A', true);
     $foreignTenant = createDashboardTenant($db, 'B', false);
     $product = 'Producto dashboard firmado ' . bin2hex(random_bytes(3));

--- a/Blue-Cat/scripts/test-security-foundation.php
+++ b/Blue-Cat/scripts/test-security-foundation.php
@@ -49,6 +49,10 @@ if (($_ENV['APP_ENV'] ?? '') !== 'test' && !in_array('--allow-production', $_SER
 
 $db = new mysqli($_ENV['DB_HOST'] ?? 'localhost', $_ENV['DB_USER'] ?? '', $_ENV['DB_PASSWORD'] ?? '', $_ENV['DB_NAME'] ?? '', (int)($_ENV['DB_PORT'] ?? 3306));
 $db->set_charset('utf8mb4');
+$testTimezone = (string)($_ENV['APP_TIMEZONE'] ?? 'America/Santiago');
+if (!in_array($testTimezone, timezone_identifiers_list(), true)) $testTimezone = 'America/Santiago';
+$testOffset = (new DateTimeImmutable('now', new DateTimeZone($testTimezone)))->format('P');
+$db->query("SET time_zone='".$db->real_escape_string($testOffset)."'");
 $base = rtrim(securityTestOption('--base-url') ?? 'http://localhost/Blue-Cat/assets/api', '/');
 $suffix = bin2hex(random_bytes(6));
 $username = 'st-'.$suffix;

--- a/blue-cat-landing/.dockerignore
+++ b/blue-cat-landing/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.next
+node_modules
+coverage
+storage
+.env
+.env.*
+*.log
+docs
+README.md
+SPRINT_2_ACCEPTANCE.md

--- a/blue-cat-landing/.env.example
+++ b/blue-cat-landing/.env.example
@@ -1,7 +1,11 @@
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_COMMERCIAL_EMAIL=ventas@tu-dominio.cl
+APP_ENV=development
+DEPLOYMENT_COMMIT=
+PUBLIC_INDEXING_ENABLED=false
 DATABASE_URL=mysql://root@127.0.0.1:3306/blue_cat_commercial
 DATABASE_TIMEZONE=local
+DATABASE_CREATE_ALLOWED=true
 # Identidad: genere valores aleatorios antes de habilitar el portal.
 # IDENTITY_DATA_KEY debe ser exactamente 32 bytes codificados en Base64.
 IDENTITY_DATA_KEY=

--- a/blue-cat-landing/Dockerfile
+++ b/blue-cat-landing/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+ARG NODE_VERSION=22.22.0
+FROM node:${NODE_VERSION}-bookworm-slim AS base
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+
+FROM base AS dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM base AS builder
+ARG NEXT_PUBLIC_SITE_URL=https://staging.blue-cat.test
+ARG NEXT_PUBLIC_COMMERCIAL_EMAIL=ventas@blue-cat.test
+ARG NEXT_PUBLIC_COMMERCIAL_CURRENCY_DECIMALS=0
+ARG PUBLIC_INDEXING_ENABLED=false
+ENV NODE_ENV=production \
+    NEXT_PUBLIC_SITE_URL=${NEXT_PUBLIC_SITE_URL} \
+    NEXT_PUBLIC_COMMERCIAL_EMAIL=${NEXT_PUBLIC_COMMERCIAL_EMAIL} \
+    NEXT_PUBLIC_COMMERCIAL_CURRENCY_DECIMALS=${NEXT_PUBLIC_COMMERCIAL_CURRENCY_DECIMALS} \
+    PUBLIC_INDEXING_ENABLED=${PUBLIC_INDEXING_ENABLED}
+COPY --from=dependencies /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM base AS migrator
+ENV NODE_ENV=production
+COPY --from=dependencies /app/node_modules ./node_modules
+COPY package.json package-lock.json tsconfig.json ./
+COPY scripts/migrate.ts ./scripts/migrate.ts
+COPY database ./database
+USER node
+CMD ["./node_modules/.bin/tsx", "scripts/migrate.ts"]
+
+FROM base AS runner
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+RUN mkdir -p /app/.next/cache && chown -R node:node /app
+COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+USER node
+EXPOSE 3000
+HEALTHCHECK --interval=20s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:3000/api/health/ready').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+CMD ["node", "server.js"]

--- a/blue-cat-landing/deploy/staging/.env.staging.example
+++ b/blue-cat-landing/deploy/staging/.env.staging.example
@@ -1,0 +1,50 @@
+# Docker Compose
+STAGING_HOST=staging.example.com
+PORTAL_IMAGE_REPOSITORY=ghcr.io/lifilab/blue-cat-portal
+PORTAL_IMAGE_TAG=replace-with-commit-sha
+PORTAL_DB_NAME=blue_cat_commercial_staging
+PORTAL_DB_USER=bluecat_portal
+PORTAL_DB_PASSWORD=
+PORTAL_DB_ROOT_PASSWORD=
+BACKUP_AGE_RECIPIENT=
+
+# Aplicación pública: solo landing y portal comercial.
+APP_ENV=staging
+NODE_ENV=production
+NEXT_TELEMETRY_DISABLED=1
+DEPLOYMENT_COMMIT=
+NEXT_PUBLIC_SITE_URL=https://staging.example.com
+NEXT_PUBLIC_COMMERCIAL_EMAIL=ventas@example.com
+PUBLIC_INDEXING_ENABLED=false
+
+# Base privada. Use una contraseña alfanumérica aleatoria para evitar problemas de URL encoding.
+DATABASE_URL=
+DATABASE_TIMEZONE=local
+DATABASE_CREATE_ALLOWED=false
+
+# Secretos independientes; nunca reutilice valores.
+IDENTITY_DATA_KEY=
+IDENTITY_HASH_PEPPER=
+OUTBOX_WORKER_TOKEN=
+PURCHASE_TOKEN_SECRET=
+
+# Documentos y correo de staging.
+CURRENT_TERMS_VERSION=terms-staging-2026-08
+CURRENT_PRIVACY_VERSION=privacy-staging-2026-08
+CURRENT_MARKETING_CONSENT_VERSION=marketing-staging-2026-08
+EMAIL_PROVIDER=resend
+EMAIL_FROM="Blue Cat Staging <cuentas@example.com>"
+RESEND_API_KEY=
+
+# Barreras obligatorias de staging.
+COMMERCE_ENABLED=false
+LEGAL_STATUS=draft
+BANK_TRANSFER_INSTRUCTIONS=
+PYME_PRICE_MINOR=
+ENTERPRISE_PRICE_MINOR=
+COMMERCIAL_CURRENCY=CLP
+COMMERCIAL_CURRENCY_DECIMALS=0
+NEXT_PUBLIC_COMMERCIAL_CURRENCY_DECIMALS=0
+OFFER_VERSION=
+OFFER_VALID_DAYS=7
+PAYMENT_EVIDENCE_DIR=payment-evidence

--- a/blue-cat-landing/deploy/staging/Caddyfile
+++ b/blue-cat-landing/deploy/staging/Caddyfile
@@ -1,0 +1,18 @@
+{$STAGING_HOST} {
+  encode zstd gzip
+
+  reverse_proxy portal:3000 {
+    health_uri /api/health/ready
+    health_interval 15s
+    health_timeout 5s
+  }
+
+  header {
+    -Server
+  }
+
+  log {
+    output stdout
+    format json
+  }
+}

--- a/blue-cat-landing/deploy/staging/compose.yml
+++ b/blue-cat-landing/deploy/staging/compose.yml
@@ -1,0 +1,106 @@
+name: blue-cat-commercial-staging
+
+services:
+  database:
+    image: mysql:8.4
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${PORTAL_DB_NAME:?PORTAL_DB_NAME is required}
+      MYSQL_USER: ${PORTAL_DB_USER:?PORTAL_DB_USER is required}
+      MYSQL_PASSWORD: ${PORTAL_DB_PASSWORD:?PORTAL_DB_PASSWORD is required}
+      MYSQL_ROOT_PASSWORD: ${PORTAL_DB_ROOT_PASSWORD:?PORTAL_DB_ROOT_PASSWORD is required}
+    volumes:
+      - portal-db:/var/lib/mysql
+    networks: [data]
+    expose: ["3306"]
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    security_opt: ["no-new-privileges:true"]
+
+  migrate:
+    image: ${PORTAL_IMAGE_REPOSITORY:-ghcr.io/lifilab/blue-cat-portal}:${PORTAL_IMAGE_TAG:?PORTAL_IMAGE_TAG is required}-migrator
+    restart: "no"
+    env_file: .env.staging
+    depends_on:
+      database:
+        condition: service_healthy
+    networks: [data]
+    read_only: true
+    tmpfs: ["/tmp"]
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
+
+  portal:
+    image: ${PORTAL_IMAGE_REPOSITORY:-ghcr.io/lifilab/blue-cat-portal}:${PORTAL_IMAGE_TAG:?PORTAL_IMAGE_TAG is required}
+    restart: unless-stopped
+    env_file: .env.staging
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    networks: [edge, data]
+    expose: ["3000"]
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /app/.next/cache
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
+
+  outbox-worker:
+    image: ${PORTAL_IMAGE_REPOSITORY:-ghcr.io/lifilab/blue-cat-portal}:${PORTAL_IMAGE_TAG:?PORTAL_IMAGE_TAG is required}
+    restart: unless-stopped
+    environment:
+      OUTBOX_WORKER_TOKEN: ${OUTBOX_WORKER_TOKEN:?OUTBOX_WORKER_TOKEN is required}
+    command:
+      - node
+      - -e
+      - >-
+        const run=()=>fetch('http://portal:3000/api/internal/email-outbox/process',
+        {method:'POST',headers:{Authorization:'Bearer '+process.env.OUTBOX_WORKER_TOKEN}})
+        .then(r=>{if(!r.ok)throw new Error('HTTP_'+r.status);return r.text()})
+        .catch(e=>console.error(JSON.stringify({event:'outbox_tick_failed',code:e.message})));
+        run();setInterval(run,30000)
+    depends_on:
+      portal:
+        condition: service_healthy
+    networks: [data]
+    read_only: true
+    tmpfs: ["/tmp"]
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
+    healthcheck:
+      disable: true
+
+  proxy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    environment:
+      STAGING_HOST: ${STAGING_HOST:?STAGING_HOST is required}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      portal:
+        condition: service_healthy
+    networks: [edge]
+    cap_drop: ["ALL"]
+    cap_add: ["NET_BIND_SERVICE"]
+    security_opt: ["no-new-privileges:true"]
+
+networks:
+  edge: {}
+  data:
+    internal: true
+
+volumes:
+  portal-db: {}
+  caddy-data: {}
+  caddy-config: {}

--- a/blue-cat-landing/docs/deployment.md
+++ b/blue-cat-landing/docs/deployment.md
@@ -1,5 +1,7 @@
 # Despliegue
 
+El entorno público de staging tiene un procedimiento reproducible y una frontera explícita en [staging-deployment.md](staging-deployment.md). Su aceptación se registra con [staging-e2e-checklist.md](staging-e2e-checklist.md). Ningún despliegue de la landing autoriza exponer el ERP/POS local.
+
 ## Desarrollo
 
 1. Copia `.env.example` a `.env.local`.

--- a/blue-cat-landing/docs/staging-deployment.md
+++ b/blue-cat-landing/docs/staging-deployment.md
@@ -1,0 +1,147 @@
+# Despliegue de staging
+
+## Alcance y frontera pública
+
+Staging publica exclusivamente la landing y el portal comercial de `blue-cat-landing/`. El ERP/POS de `Blue-Cat/`, su base operativa, sus endpoints PHP y sus instaladores no forman parte de la imagen ni del `compose.yml`.
+
+```mermaid
+flowchart LR
+  Internet -->|HTTPS 443| Proxy[Caddy]
+  Proxy -->|HTTP privado 3000| Portal[Landing + portal comercial]
+  Portal -->|red interna| DB[(MySQL portal)]
+  Worker[Worker de correo] -->|token interno| Portal
+  Portal -->|API HTTPS| Email[Proveedor de correo]
+  ERP[ERP/POS local] -. sin ruta ni conexión .- Internet
+  ERP -. base separada .- DB
+```
+
+La imagen Docker usa `blue-cat-landing/` como contexto. Esto evita que un error de configuración copie el ERP local al artefacto público.
+
+## Requisitos externos
+
+- Servidor Linux de staging con Docker Engine y Docker Compose v2.
+- Dominio o subdominio con registro DNS apuntando al servidor.
+- Puertos 80 y 443 públicos; 3000 y 3306 cerrados en firewall.
+- Acceso de solo lectura al paquete privado de GHCR, si el repositorio no publica imágenes abiertas.
+- Dominio remitente verificado y credencial de Resend exclusiva de staging.
+- GitHub Environment `staging` y variable `STAGING_COMMERCIAL_EMAIL`.
+- `age` y una clave pública de backup custodiada fuera del servidor.
+- Copias cifradas fuera del servidor y una restauración ensayada.
+
+## 1. Publicar imágenes inmutables
+
+En GitHub Actions ejecuta `Publish staging images` desde `master`:
+
+- `site_url`: origen HTTPS, por ejemplo `https://staging.dominio.cl`.
+- `image_tag`: etiqueta operativa como `staging-2026-08-08`.
+
+El workflow publica dos imágenes con SBOM y procedencia:
+
+- `ghcr.io/lifilab/blue-cat-portal:<commit>`
+- `ghcr.io/lifilab/blue-cat-portal:<commit>-migrator`
+
+Para desplegar se usa siempre el SHA completo del commit, no la etiqueta mutable.
+
+## 2. Preparar el servidor
+
+Copiar únicamente estos archivos a un directorio operativo, por ejemplo `/opt/blue-cat-staging`:
+
+- `deploy/staging/compose.yml`
+- `deploy/staging/Caddyfile`
+- `deploy/staging/.env.staging.example` como `.env.staging`
+
+La cuenta del servicio debe ser no privilegiada. `.env.staging` debe tener permisos `0600` y no debe entrar en Git, tickets, capturas ni respaldos sin cifrar.
+
+Generar valores independientes con un CSPRNG:
+
+```bash
+openssl rand -base64 32   # IDENTITY_DATA_KEY
+openssl rand -hex 32      # cada pepper/token/password restante
+```
+
+`DATABASE_URL` debe apuntar al host interno `database`, nunca a la base del ERP/POS. Use una contraseña alfanumérica aleatoria o codifíquela correctamente para URI. En staging, `DATABASE_CREATE_ALLOWED=false`: el contenedor MySQL crea el esquema inicial y el migrador no recibe privilegios globales para crear otras bases.
+
+## 3. Preflight obligatorio
+
+Desde una copia del proyecto, cargando las variables reales sin imprimirlas:
+
+```bash
+cd blue-cat-landing
+npm ci
+set -a; . /opt/blue-cat-staging/.env.staging; set +a
+npm run staging:verify-config
+```
+
+El preflight bloquea el despliegue si detecta HTTP, localhost, secretos débiles o repetidos, credenciales bootstrap persistentes, indexación pública o comercio real habilitado.
+
+Validar además la composición:
+
+```bash
+cd /opt/blue-cat-staging
+docker compose --env-file .env.staging -f compose.yml config --quiet
+```
+
+## 4. Backup, migración y arranque
+
+En el primer despliegue no existe backup anterior. En cada actualización posterior:
+
+```bash
+mkdir -p backups
+docker compose --env-file .env.staging -f compose.yml exec -T database \
+  sh -c 'mysqldump --single-transaction -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' \
+  | gzip | age -r "$BACKUP_AGE_RECIPIENT" \
+  > "backups/portal-$(date -u +%Y%m%dT%H%M%SZ).sql.gz.age"
+```
+
+Después:
+
+```bash
+docker compose --env-file .env.staging -f compose.yml pull
+docker compose --env-file .env.staging -f compose.yml up -d database
+docker compose --env-file .env.staging -f compose.yml run --rm migrate
+docker compose --env-file .env.staging -f compose.yml up -d portal outbox-worker proxy
+docker compose --env-file .env.staging -f compose.yml ps
+```
+
+Las migraciones son idempotentes y verifican SHA-256. Una migración ya aplicada nunca se modifica: se agrega otra.
+
+## 5. Verificación posterior
+
+Ejecutar desde una red externa al servidor:
+
+```powershell
+$env:STAGING_URL = "https://staging.dominio.cl"
+npm run staging:smoke
+Remove-Item Env:STAGING_URL
+```
+
+El smoke test verifica landing, TLS/headers, liveness, readiness con base, `robots.txt`, aislamiento de rutas internas, comercio deshabilitado y ausencia de rutas conocidas del ERP/POS.
+
+Luego ejecutar [staging-e2e-checklist.md](staging-e2e-checklist.md) y adjuntar evidencias al release candidato.
+
+## 6. Operador de prueba
+
+El bootstrap se ejecuta una sola vez desde un entorno administrativo con acceso a la red de datos. Las variables `OPERATOR_*` se eliminan inmediatamente y el operador activa MFA antes de usar rutas administrativas. No se envían contraseñas por correo.
+
+Para staging puede construirse temporalmente el target `migrator` con el código aprobado y ejecutar `npm run identity:bootstrap-operator`; nunca se habilita acceso remoto a MySQL para facilitar este paso.
+
+## 7. Observación y alertas mínimas
+
+- Monitor externo: `GET /api/health/live` cada minuto.
+- Monitor de dependencia: `GET /api/health/ready`; alerta tras tres fallos.
+- Alerta de contenedor reiniciando, disco mayor a 80 %, backup fallido y outbox en estado `dead`.
+- Logs JSON de Caddy y aplicación con retención definida y sin cuerpos, tokens, cookies ni datos bancarios.
+- Revisar certificados y expiración DNS antes de cada demostración.
+
+## 8. Rollback
+
+1. Detener ingreso de tráfico si hay riesgo de corrupción o seguridad.
+2. Guardar logs y métricas del incidente.
+3. Cambiar `PORTAL_IMAGE_TAG` al SHA anterior y ejecutar `docker compose up -d`.
+4. No revertir la base automáticamente si la migración fue aditiva y compatible.
+5. Si la migración exige restauración, detener portal/worker, validar el backup en una base temporal y restaurar con doble aprobación.
+6. Repetir smoke y los casos críticos E2E antes de reabrir tráfico.
+
+## Criterio de promoción
+
+Staging está listo solo cuando el workflow `Staging readiness` está verde, el preflight real pasa, health permanece estable, backup/restauración tienen evidencia y todos los casos críticos del checklist E2E están aprobados. Esto no habilita pagos reales ni convierte staging en producción.

--- a/blue-cat-landing/docs/staging-e2e-checklist.md
+++ b/blue-cat-landing/docs/staging-e2e-checklist.md
@@ -1,0 +1,176 @@
+# Checklist E2E de staging
+
+## Registro de ejecución
+
+| Campo | Valor |
+|---|---|
+| URL | |
+| Commit / imagen | |
+| Fecha y zona horaria | |
+| QA responsable | |
+| Navegadores | Edge / Chrome / Firefox |
+| Dispositivos | 390 px / 768 px / 1366 px |
+| Base restaurada desde backup | Sí / No |
+| Evidencias | |
+
+Estados permitidos: `PASS`, `FAIL`, `BLOCKED` o `N/A` con justificación. Ningún caso crítico puede quedar `FAIL`, `BLOCKED` o sin evidencia.
+
+## A. Gate técnico y perímetro — crítico
+
+- [ ] Todos los checks del commit están verdes: baseline, secretos, dependencias, CodeQL, MySQL, portal y staging readiness.
+- [ ] La imagen desplegada coincide con el SHA aprobado y tiene SBOM/procedencia.
+- [ ] DNS resuelve al servidor de staging y HTTPS usa un certificado válido.
+- [ ] HTTP redirige a HTTPS; TLS obsoleto está deshabilitado.
+- [ ] Solo 80/443 son públicos. 3000/3306 no responden desde Internet.
+- [ ] `/api/health/live` responde `200` sin secretos ni detalles internos.
+- [ ] `/api/health/ready` responde `200` con la base disponible y `503` al interrumpirla.
+- [ ] `/Blue-Cat/`, `/public/pos.html` y `/assets/api/auth.php` responden `404`.
+- [ ] No existen artefactos, rutas, archivos PHP, dumps ni credenciales del ERP/POS en la imagen.
+- [ ] `robots.txt` bloquea todo staging y todas las respuestas incluyen `X-Robots-Tag: noindex`.
+- [ ] El smoke automático termina con `status: passed`.
+
+## B. Landing, contenido y experiencia visual — alta
+
+- [ ] Inicio carga sin errores de consola, recursos `4xx/5xx` ni saltos visibles de layout.
+- [ ] Header, menú móvil, footer, CTA, licencias, módulos, Cloud Sync, tutoriales, FAQ y contacto navegan correctamente.
+- [ ] No aparece “Crear cuenta” en el ERP/POS local; el registro comercial vive solo en el portal.
+- [ ] Planes PYME y Enterprise explican diferencias sin prometer funciones no entregadas.
+- [ ] Cloud Sync aparece como servicio mensual separado, no incluido por defecto.
+- [ ] Compra por transferencia se presenta deshabilitada o como entorno de prueba, sin datos bancarios reales.
+- [ ] Textos, acentos, moneda CLP, fechas y enlaces legales se renderizan correctamente.
+- [ ] Logo, favicon, Open Graph y estados hover/focus mantienen calidad visual.
+- [ ] Vista 390 px no tiene scroll horizontal, superposición de modales ni botones fuera de pantalla.
+- [ ] Vista 768 px mantiene jerarquía y controles táctiles de al menos 44 px.
+- [ ] Vista 1366 px no deja secciones rotas, excesivamente vacías o ilegibles.
+- [ ] Navegación completa con teclado: orden lógico, foco visible, Escape y retorno de foco en modales.
+- [ ] “Saltar al contenido”, títulos, labels, mensajes de error y contraste cumplen WCAG 2.1 AA.
+- [ ] Con animaciones reducidas activadas no quedan transiciones obligatorias.
+
+## C. Registro y verificación de correo — crítico
+
+- [ ] Cuenta nueva válida devuelve respuesta genérica y crea usuario pendiente.
+- [ ] Consentimientos obligatorios registran exactamente la versión vigente; marketing conserva el valor elegido.
+- [ ] Términos desactualizados devuelven `409 LEGAL_VERSION_OUTDATED` y la UI solicita recargar.
+- [ ] Correo duplicado recibe la misma respuesta genérica y no revela si existe.
+- [ ] Email inválido, contraseña débil, cuerpo no JSON y cuerpo grande muestran errores seguros y útiles.
+- [ ] Enlace de verificación real llega desde el remitente de staging y apunta al dominio correcto.
+- [ ] Token válido activa la cuenta una sola vez.
+- [ ] Token reutilizado, alterado o vencido es rechazado sin filtrar datos.
+- [ ] Reenvío invalida enlaces anteriores y respeta rate limit.
+- [ ] Outbox no conserva el payload cifrado después del envío exitoso.
+
+## D. Login, sesiones y recuperación — crítico
+
+- [ ] Usuario no verificado no puede iniciar sesión.
+- [ ] Credenciales correctas crean cookies `HttpOnly`, `Secure` y `SameSite=Strict`.
+- [ ] Credenciales incorrectas no distinguen correo inexistente de contraseña errónea.
+- [ ] Cinco fallos activan bloqueo temporal y el desbloqueo respeta la política.
+- [ ] Navegar o llamar APIs sin sesión devuelve `401` coherente.
+- [ ] Mutaciones sin `Origin` válido o sin CSRF devuelven `403`.
+- [ ] Logout revoca la sesión servidor y elimina cookies.
+- [ ] Timeout inactivo y límite absoluto invalidan la sesión.
+- [ ] Solicitar recuperación siempre entrega respuesta genérica.
+- [ ] Enlace de recuperación llega al correo correcto, vence y solo funciona una vez.
+- [ ] Cambiar la contraseña revoca todas las sesiones anteriores.
+- [ ] La contraseña nunca aparece en URL, correo, logs, auditoría o respuestas.
+
+## E. MFA y operador — crítico
+
+- [ ] Bootstrap crea o actualiza únicamente al operador solicitado y no imprime la contraseña.
+- [ ] Variables `OPERATOR_*` quedan eliminadas después del bootstrap.
+- [ ] Operador sin MFA no puede usar endpoints administrativos.
+- [ ] Enrolamiento genera TOTP y códigos de recuperación; el secreto se almacena cifrado.
+- [ ] Código TOTP válido activa MFA; código inválido no lo activa.
+- [ ] Login posterior exige TOTP y una sesión con nivel MFA.
+- [ ] Cliente normal no puede elevarse a operador ni acceder a `/api/admin/*`.
+
+## F. Organización, membresía y aislamiento — crítico
+
+- [ ] Usuario verificado crea una organización con identificador tributario válido.
+- [ ] Usuario pendiente no puede crear organizaciones.
+- [ ] La membresía inicial queda como propietario de esa organización.
+- [ ] Límite de organizaciones se aplica en backend, no solo en UI.
+- [ ] Actualizar perfil de facturación requiere sesión, CSRF y pertenencia.
+- [ ] Cambiar el ID de organización en URL/cuerpo no permite leer o editar otra cuenta (IDOR).
+- [ ] Dos usuarios de organizaciones distintas no comparten datos comerciales, consentimientos ni sesiones.
+- [ ] Auditoría registra actor, organización, evento, request ID y fecha sin secretos.
+
+## G. Correo y outbox — alta
+
+- [ ] Worker sin bearer token devuelve `401`.
+- [ ] Token incorrecto devuelve `401` con comparación segura.
+- [ ] Dos workers simultáneos no envían dos veces el mismo mensaje.
+- [ ] Fallo transitorio reintenta con backoff y conserva trazabilidad.
+- [ ] Quinto fallo mueve el mensaje a `dead` y genera alerta operativa.
+- [ ] Un mensaje enviado purga payload y registra ID del proveedor.
+- [ ] HTML escapa nombre y URL; no admite inyección.
+- [ ] Correos se visualizan correctamente en Gmail, Outlook y móvil.
+
+## H. Canal comercial de staging — crítico
+
+- [ ] `COMMERCE_ENABLED=false` y `LEGAL_STATUS=draft` pasan el preflight.
+- [ ] No se muestran cuentas bancarias reales, links de pago productivos ni carga de comprobantes operativa.
+- [ ] Conciliación administrativa devuelve `503 COMMERCE_NOT_ENABLED` antes de modificar datos.
+- [ ] Una solicitud de información/cotización válida genera tracking sin prometer licencia activada.
+- [ ] Idempotency key repetida con el mismo contenido no duplica la solicitud.
+- [ ] Idempotency key repetida con contenido distinto devuelve conflicto.
+- [ ] Honeypot, rate limit y validación de tamaño bloquean abuso.
+- [ ] Seguimiento con token alterado no expone datos ni permite enumerar solicitudes.
+
+## I. Base, migraciones y resiliencia — crítico
+
+- [ ] Base comercial usa credenciales y esquema distintos al ERP/POS.
+- [ ] MySQL no tiene puerto publicado y acepta conexiones solo en red privada.
+- [ ] Migrar una base vacía aplica todas las migraciones en orden.
+- [ ] Repetir migraciones no modifica datos y reporta `skip`.
+- [ ] Modificar una migración aplicada provoca `MIGRATION_CHANGED_*` y bloquea el arranque.
+- [ ] Backup previo se crea, cifra, copia fuera del host y valida por checksum.
+- [ ] Restauración en una base temporal recupera conteos, relaciones y restricciones.
+- [ ] Reiniciar portal, proxy, worker y servidor conserva datos y sesiones válidas.
+- [ ] Caída de MySQL vuelve readiness `503` sin mostrar stack trace; al volver se recupera.
+- [ ] Disco lleno o permisos inválidos producen alerta y no una respuesta engañosa.
+
+## J. Seguridad y observabilidad — crítico
+
+- [ ] CSP, HSTS, `nosniff`, `DENY`, Referrer-Policy y Permissions-Policy están presentes.
+- [ ] No hay CORS abierto; peticiones cross-origin mutantes son rechazadas.
+- [ ] SQL usa parámetros y pruebas de payloads comunes no alteran consultas.
+- [ ] Valores HTML/URL controlados por usuario no ejecutan XSS almacenado o reflejado.
+- [ ] Rate limits persisten entre réplicas/reinicios según el diseño actual.
+- [ ] Logs no contienen contraseña, token, cookie, API key, comprobante ni datos bancarios.
+- [ ] Eventos críticos incluyen request ID y pueden correlacionarse entre proxy, app y auditoría.
+- [ ] Alertas se disparan por health, reinicios, disco, backup, errores 5xx y outbox `dead`.
+- [ ] Dependencias y secretos vuelven a escanearse sobre la imagen/commit desplegado.
+
+## K. Fallos, rollback y cierre — crítico
+
+- [ ] Despliegue de una imagen inválida no reemplaza la instancia sana.
+- [ ] Rollback a SHA anterior recupera servicio sin reutilizar secretos ni imágenes locales.
+- [ ] Si una migración requiere restauración, el procedimiento fue ensayado con doble aprobación.
+- [ ] Después del rollback pasan smoke, login, aislamiento y consulta de organización.
+- [ ] Se documentan defectos con severidad, pasos, evidencia, responsable y sprint.
+- [ ] Product Owner, Tech Lead y QA firman el resultado.
+
+## L. Pruebas fuera del staging público
+
+Estas pruebas pertenecen al laboratorio local/RC y nunca justifican publicar el ERP/POS:
+
+- [ ] Instalación limpia y actualización conservando usuarios, productos y ventas.
+- [ ] Acceso directo, aplicación de escritorio, certificados locales y arranque sin Laragon.
+- [ ] Crear/importar/exportar productos, actualizar stock, costo, precio e impuestos.
+- [ ] Crear empleados y validar permisos reales de cajero, bodeguero y supervisor.
+- [ ] Abrir caja, vender por unidad/peso, promociones, clientes, pago y boleta con logo.
+- [ ] Venta visible el mismo día para empleado autorizado y administrador; cuadratura consistente.
+- [ ] Anulación con autorización temporal de supervisor y auditoría completa.
+- [ ] Dos POS en LAN conectan al servidor local sin exponerlo a Internet.
+- [ ] Activación/licencia, descarga protegida y verificación firmada se prueban cuando el sprint de licenciamiento esté implementado.
+
+## Resultado
+
+| Severidad | PASS | FAIL | BLOCKED | N/A |
+|---|---:|---:|---:|---:|
+| Crítica | | | | |
+| Alta | | | | |
+| Total | | | | |
+
+Decisión: `APROBADO`, `APROBADO CON RIESGO ACEPTADO` o `RECHAZADO`.

--- a/blue-cat-landing/next.config.ts
+++ b/blue-cat-landing/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const productionOnlyCsp = process.env.NODE_ENV === "production" ? "; upgrade-insecure-requests" : "";
 const developmentScriptCsp = process.env.NODE_ENV === "production" ? "" : " 'unsafe-eval'";
+const publicIndexingEnabled = process.env.PUBLIC_INDEXING_ENABLED === "true";
 const securityHeaders = [
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
@@ -12,8 +13,10 @@ const securityHeaders = [
 ];
 
 if (process.env.NODE_ENV === "production") securityHeaders.push({ key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" });
+if (!publicIndexingEnabled) securityHeaders.push({ key: "X-Robots-Tag", value: "noindex, nofollow, noarchive" });
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   poweredByHeader: false,
   reactStrictMode: true,
   async headers() {

--- a/blue-cat-landing/package.json
+++ b/blue-cat-landing/package.json
@@ -14,7 +14,9 @@
     "test": "vitest run",
     "db:migrate": "tsx scripts/migrate.ts",
     "identity:bootstrap-operator": "tsx scripts/bootstrap-operator.ts",
-    "test:identity": "tsx scripts/test-identity-flow.ts"
+    "test:identity": "tsx scripts/test-identity-flow.ts",
+    "staging:verify-config": "tsx scripts/verify-staging-config.ts",
+    "staging:smoke": "tsx scripts/smoke-staging.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/blue-cat-landing/scripts/migrate.ts
+++ b/blue-cat-landing/scripts/migrate.ts
@@ -17,7 +17,9 @@ async function main() {
     multipleStatements: true,
   });
   try {
-    await connection.query(`CREATE DATABASE IF NOT EXISTS \`${database}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`);
+    if (process.env.DATABASE_CREATE_ALLOWED !== "false") {
+      await connection.query(`CREATE DATABASE IF NOT EXISTS \`${database}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`);
+    }
     await connection.query(`USE \`${database}\``);
     await connection.query(`
       CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/blue-cat-landing/scripts/smoke-staging.ts
+++ b/blue-cat-landing/scripts/smoke-staging.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+
+const configuredUrl = process.env.STAGING_URL?.trim();
+if (!configuredUrl) throw new Error("STAGING_URL_REQUIRED");
+const baseUrl = new URL(configuredUrl);
+if (baseUrl.protocol !== "https:" && process.env.ALLOW_HTTP_SMOKE !== "true") {
+  throw new Error("STAGING_URL_MUST_USE_HTTPS");
+}
+const origin = baseUrl.origin;
+
+async function fetchPath(path: string, init?: RequestInit): Promise<Response> {
+  const response = await fetch(new URL(path, origin), {
+    redirect: "follow",
+    signal: AbortSignal.timeout(10_000),
+    ...init,
+  });
+  assert.equal(new URL(response.url).origin, origin, `Redirección fuera de staging: ${path}`);
+  return response;
+}
+
+async function main() {
+  const home = await fetchPath("/");
+  assert.equal(home.status, 200, "La landing debe responder 200.");
+  assert.match(await home.text(), /Blue Cat/i, "La landing debe contener la marca Blue Cat.");
+  assert.equal(home.headers.get("x-content-type-options"), "nosniff");
+  assert.equal(home.headers.get("x-frame-options"), "DENY");
+  assert.match(home.headers.get("content-security-policy") ?? "", /default-src 'self'/);
+  assert.match(home.headers.get("x-robots-tag") ?? "", /noindex/i);
+  if (baseUrl.protocol === "https:") assert.match(home.headers.get("strict-transport-security") ?? "", /max-age=/);
+
+  const live = await fetchPath("/api/health/live");
+  assert.equal(live.status, 200, "Liveness debe responder 200.");
+  assert.equal((await live.json() as { status?: string }).status, "ok");
+
+  const ready = await fetchPath("/api/health/ready");
+  assert.equal(ready.status, 200, "Readiness debe confirmar aplicación y base de datos.");
+  assert.equal((await ready.json() as { status?: string }).status, "ready");
+
+  const robots = await fetchPath("/robots.txt");
+  assert.equal(robots.status, 200);
+  assert.match(await robots.text(), /Disallow:\s*\//i, "Staging no debe ser indexable.");
+
+  const admin = await fetchPath("/api/admin/payment-reports");
+  assert.equal(admin.status, 401, "Las rutas administrativas deben exigir autenticación.");
+
+  const worker = await fetchPath("/api/internal/email-outbox/process", { method: "POST" });
+  assert.equal(worker.status, 401, "El worker interno debe rechazar llamadas sin token.");
+
+  const disabledCommerce = await fetchPath("/api/admin/payment-reports", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Origin: origin },
+    body: "{}",
+  });
+  assert.equal(disabledCommerce.status, 503, "Staging no debe aceptar conciliaciones comerciales reales.");
+  assert.equal((await disabledCommerce.json() as { error?: { code?: string } }).error?.code, "COMMERCE_NOT_ENABLED");
+
+  for (const privatePath of ["/Blue-Cat/", "/public/pos.html", "/assets/api/auth.php"]) {
+    const response = await fetchPath(privatePath);
+    assert.equal(response.status, 404, `El ERP/POS local no debe publicarse: ${privatePath}`);
+  }
+
+  console.info(JSON.stringify({ status: "passed", origin, checks: 14 }));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : "STAGING_SMOKE_FAILED");
+  process.exitCode = 1;
+});

--- a/blue-cat-landing/scripts/verify-staging-config.ts
+++ b/blue-cat-landing/scripts/verify-staging-config.ts
@@ -1,0 +1,9 @@
+import { validateStagingEnvironment } from "../src/config/runtime-environment";
+
+const result = validateStagingEnvironment();
+if (!result.ok) {
+  console.error(JSON.stringify({ status: "invalid", errors: result.errors }, null, 2));
+  process.exitCode = 1;
+} else {
+  console.info(JSON.stringify({ status: "ready", environment: "staging" }));
+}

--- a/blue-cat-landing/src/app/api/health/live/route.test.ts
+++ b/blue-cat-landing/src/app/api/health/live/route.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+describe("GET /api/health/live", () => {
+  it("returns only non-sensitive service metadata", async () => {
+    const previous = process.env.DEPLOYMENT_COMMIT;
+    process.env.DEPLOYMENT_COMMIT = "abcdef1234567890";
+    try {
+      const response = await GET();
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      await expect(response.json()).resolves.toEqual(expect.objectContaining({
+        status: "ok",
+        service: "blue-cat-commercial-portal",
+        commit: "abcdef123456",
+      }));
+    } finally {
+      if (previous === undefined) delete process.env.DEPLOYMENT_COMMIT;
+      else process.env.DEPLOYMENT_COMMIT = previous;
+    }
+  });
+});

--- a/blue-cat-landing/src/app/api/health/live/route.ts
+++ b/blue-cat-landing/src/app/api/health/live/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      service: "blue-cat-commercial-portal",
+      environment: process.env.APP_ENV || "development",
+      commit: safeCommit(process.env.DEPLOYMENT_COMMIT),
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+function safeCommit(value: string | undefined): string {
+  const commit = value?.trim() ?? "unknown";
+  return /^[0-9a-f]{7,40}$/i.test(commit) ? commit.slice(0, 12) : "unknown";
+}

--- a/blue-cat-landing/src/app/api/health/ready/route.ts
+++ b/blue-cat-landing/src/app/api/health/ready/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { validateStagingEnvironment } from "@/config/runtime-environment";
+import { getPool } from "@/infrastructure/database/mysql";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (process.env.APP_ENV === "staging" && !validateStagingEnvironment().ok) {
+    return unavailable();
+  }
+
+  let connection: Awaited<ReturnType<ReturnType<typeof getPool>["getConnection"]>> | undefined;
+  try {
+    connection = await getPool().getConnection();
+    await connection.query({ sql: "SELECT 1", timeout: 2_000 });
+    return NextResponse.json(
+      { status: "ready", service: "blue-cat-commercial-portal" },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch {
+    return unavailable();
+  } finally {
+    connection?.release();
+  }
+}
+
+function unavailable() {
+  return NextResponse.json(
+    { status: "unavailable", service: "blue-cat-commercial-portal" },
+    { status: 503, headers: { "Cache-Control": "no-store", "Retry-After": "10" } },
+  );
+}

--- a/blue-cat-landing/src/app/robots.ts
+++ b/blue-cat-landing/src/app/robots.ts
@@ -1,3 +1,12 @@
 import type { MetadataRoute } from "next";
 import { siteConfig } from "@/config/site";
-export default function robots():MetadataRoute.Robots{return {rules:{userAgent:"*",allow:"/",disallow:["/api/","/comprar/confirmacion"]},sitemap:`${siteConfig.url}/sitemap.xml`};}
+
+export default function robots(): MetadataRoute.Robots {
+  if (process.env.PUBLIC_INDEXING_ENABLED !== "true") {
+    return { rules: { userAgent: "*", disallow: "/" } };
+  }
+  return {
+    rules: { userAgent: "*", allow: "/", disallow: ["/api/", "/comprar/confirmacion"] },
+    sitemap: `${siteConfig.url}/sitemap.xml`,
+  };
+}

--- a/blue-cat-landing/src/config/runtime-environment.test.ts
+++ b/blue-cat-landing/src/config/runtime-environment.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { validateStagingEnvironment } from "./runtime-environment";
+
+function validEnvironment(): NodeJS.ProcessEnv {
+  return {
+    APP_ENV: "staging",
+    NODE_ENV: "production",
+    NEXT_PUBLIC_SITE_URL: "https://staging.blue-cat.test",
+    STAGING_HOST: "staging.blue-cat.test",
+    DEPLOYMENT_COMMIT: "a".repeat(40),
+    PORTAL_IMAGE_TAG: "a".repeat(40),
+    DATABASE_URL: `mysql://portal:${"d".repeat(40)}@database:3306/blue_cat_portal`,
+    DATABASE_CREATE_ALLOWED: "false",
+    IDENTITY_DATA_KEY: Buffer.alloc(32, 7).toString("base64"),
+    IDENTITY_HASH_PEPPER: "h".repeat(64),
+    OUTBOX_WORKER_TOKEN: "o".repeat(64),
+    PURCHASE_TOKEN_SECRET: "p".repeat(64),
+    EMAIL_PROVIDER: "resend",
+    RESEND_API_KEY: `re_${"r".repeat(32)}`,
+    EMAIL_FROM: "Blue Cat <cuentas@blue-cat.test>",
+    CURRENT_TERMS_VERSION: "terms-staging-2026-08",
+    CURRENT_PRIVACY_VERSION: "privacy-staging-2026-08",
+    CURRENT_MARKETING_CONSENT_VERSION: "marketing-staging-2026-08",
+    COMMERCE_ENABLED: "false",
+    LEGAL_STATUS: "draft",
+    PUBLIC_INDEXING_ENABLED: "false",
+  };
+}
+
+describe("validateStagingEnvironment", () => {
+  it("accepts a hardened staging configuration", () => {
+    expect(validateStagingEnvironment(validEnvironment())).toEqual({ ok: true, errors: [] });
+  });
+
+  it("rejects public commerce, indexing, insecure URLs and persisted bootstrap credentials", () => {
+    const environment = validEnvironment();
+    environment.NEXT_PUBLIC_SITE_URL = "http://localhost:3000/path";
+    environment.COMMERCE_ENABLED = "true";
+    environment.PUBLIC_INDEXING_ENABLED = "true";
+    environment.OPERATOR_PASSWORD = "must-not-remain";
+    const result = validateStagingEnvironment(environment);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      "COMMERCE_ENABLED_MUST_BE_FALSE",
+      "PUBLIC_INDEXING_ENABLED_MUST_BE_FALSE",
+      "SITE_URL_MUST_USE_HTTPS",
+      "SITE_URL_MUST_BE_ORIGIN_ONLY",
+      "SITE_URL_MUST_NOT_BE_LOCAL",
+      "OPERATOR_PASSWORD_MUST_NOT_PERSIST",
+    ]));
+  });
+
+  it("requires an immutable image tag that matches the public host", () => {
+    const environment = validEnvironment();
+    environment.PORTAL_IMAGE_TAG = "staging-latest";
+    environment.STAGING_HOST = "other.blue-cat.test";
+    const result = validateStagingEnvironment(environment);
+
+    expect(result.errors).toEqual(expect.arrayContaining([
+      "PORTAL_IMAGE_TAG_MUST_MATCH_COMMIT",
+      "STAGING_HOST_MUST_MATCH_SITE_URL",
+    ]));
+  });
+
+  it("rejects missing, repeated or malformed secrets", () => {
+    const environment = validEnvironment();
+    environment.IDENTITY_DATA_KEY = "not-base64";
+    environment.IDENTITY_HASH_PEPPER = "x".repeat(32);
+    environment.OUTBOX_WORKER_TOKEN = "x".repeat(32);
+    environment.PURCHASE_TOKEN_SECRET = "short";
+    const result = validateStagingEnvironment(environment);
+
+    expect(result.errors).toEqual(expect.arrayContaining([
+      "IDENTITY_DATA_KEY_MUST_BE_32_BYTES",
+      "PURCHASE_TOKEN_SECRET_INVALID",
+      "STAGING_SECRETS_MUST_BE_UNIQUE",
+    ]));
+  });
+});

--- a/blue-cat-landing/src/config/runtime-environment.ts
+++ b/blue-cat-landing/src/config/runtime-environment.ts
@@ -1,0 +1,119 @@
+const forbiddenFragments = ["change-me", "replace-with", "example-secret", "tu-dominio"];
+
+export interface RuntimeEnvironmentValidation {
+  ok: boolean;
+  errors: string[];
+}
+
+export function validateStagingEnvironment(
+  environment: NodeJS.ProcessEnv = process.env,
+): RuntimeEnvironmentValidation {
+  const errors: string[] = [];
+
+  expectValue(environment, "APP_ENV", "staging", errors);
+  expectValue(environment, "NODE_ENV", "production", errors);
+  expectValue(environment, "COMMERCE_ENABLED", "false", errors);
+  expectValue(environment, "LEGAL_STATUS", "draft", errors);
+  expectValue(environment, "PUBLIC_INDEXING_ENABLED", "false", errors);
+  expectValue(environment, "DATABASE_CREATE_ALLOWED", "false", errors);
+
+  validatePublicUrl(environment.NEXT_PUBLIC_SITE_URL, errors);
+  validateDeploymentIdentity(environment, errors);
+  validateDatabaseUrl(environment.DATABASE_URL, errors);
+  validateDataKey(environment.IDENTITY_DATA_KEY, errors);
+
+  const secretNames = ["IDENTITY_HASH_PEPPER", "OUTBOX_WORKER_TOKEN", "PURCHASE_TOKEN_SECRET"] as const;
+  for (const name of secretNames) validateSecret(name, environment[name], errors);
+  const secrets = secretNames.map((name) => environment[name]?.trim()).filter(Boolean);
+  if (new Set(secrets).size !== secrets.length) errors.push("STAGING_SECRETS_MUST_BE_UNIQUE");
+
+  if (environment.EMAIL_PROVIDER !== "resend") errors.push("EMAIL_PROVIDER_MUST_BE_RESEND");
+  if (!environment.RESEND_API_KEY?.startsWith("re_") || environment.RESEND_API_KEY.length < 20) {
+    errors.push("RESEND_API_KEY_INVALID");
+  }
+  if (!environment.EMAIL_FROM || !/^.+<[^<>\s]+@[^<>\s]+>$/.test(environment.EMAIL_FROM.trim())) {
+    errors.push("EMAIL_FROM_INVALID");
+  }
+
+  for (const name of ["CURRENT_TERMS_VERSION", "CURRENT_PRIVACY_VERSION", "CURRENT_MARKETING_CONSENT_VERSION"] as const) {
+    const value = environment[name]?.trim() ?? "";
+    if (!value || containsPlaceholder(value)) errors.push(`${name}_INVALID`);
+  }
+
+  for (const name of ["OPERATOR_EMAIL", "OPERATOR_NAME", "OPERATOR_PASSWORD"] as const) {
+    if (environment[name]?.trim()) errors.push(`${name}_MUST_NOT_PERSIST`);
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+function validateDeploymentIdentity(environment: NodeJS.ProcessEnv, errors: string[]): void {
+  const commit = environment.DEPLOYMENT_COMMIT?.trim() ?? "";
+  if (!/^[0-9a-f]{40}$/i.test(commit)) errors.push("DEPLOYMENT_COMMIT_MUST_BE_FULL_SHA");
+  if (environment.PORTAL_IMAGE_TAG !== commit) errors.push("PORTAL_IMAGE_TAG_MUST_MATCH_COMMIT");
+  try {
+    const hostname = new URL(environment.NEXT_PUBLIC_SITE_URL ?? "").hostname;
+    if (!environment.STAGING_HOST || environment.STAGING_HOST !== hostname) errors.push("STAGING_HOST_MUST_MATCH_SITE_URL");
+  } catch {
+    // NEXT_PUBLIC_SITE_URL reports its own validation error.
+  }
+}
+
+function expectValue(
+  environment: NodeJS.ProcessEnv,
+  name: string,
+  expected: string,
+  errors: string[],
+): void {
+  if (environment[name] !== expected) errors.push(`${name}_MUST_BE_${expected.toUpperCase()}`);
+}
+
+function validatePublicUrl(value: string | undefined, errors: string[]): void {
+  try {
+    if (!value) throw new Error("missing");
+    const url = new URL(value);
+    if (url.protocol !== "https:") errors.push("SITE_URL_MUST_USE_HTTPS");
+    if (url.username || url.password || url.search || url.hash || (url.pathname !== "/" && url.pathname !== "")) {
+      errors.push("SITE_URL_MUST_BE_ORIGIN_ONLY");
+    }
+    if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) errors.push("SITE_URL_MUST_NOT_BE_LOCAL");
+  } catch {
+    errors.push("SITE_URL_INVALID");
+  }
+}
+
+function validateDatabaseUrl(value: string | undefined, errors: string[]): void {
+  try {
+    if (!value) throw new Error("missing");
+    const url = new URL(value);
+    if (url.protocol !== "mysql:") errors.push("DATABASE_URL_MUST_USE_MYSQL");
+    if (!url.hostname || !url.username || !url.password || !url.pathname.slice(1)) {
+      errors.push("DATABASE_URL_MISSING_CREDENTIALS_OR_DATABASE");
+    }
+    if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) errors.push("DATABASE_URL_MUST_NOT_BE_LOCALHOST");
+  } catch {
+    errors.push("DATABASE_URL_INVALID");
+  }
+}
+
+function validateDataKey(value: string | undefined, errors: string[]): void {
+  if (!value || containsPlaceholder(value)) {
+    errors.push("IDENTITY_DATA_KEY_INVALID");
+    return;
+  }
+  try {
+    if (Buffer.from(value, "base64").length !== 32) errors.push("IDENTITY_DATA_KEY_MUST_BE_32_BYTES");
+  } catch {
+    errors.push("IDENTITY_DATA_KEY_INVALID");
+  }
+}
+
+function validateSecret(name: string, value: string | undefined, errors: string[]): void {
+  const normalized = value?.trim() ?? "";
+  if (normalized.length < 32 || containsPlaceholder(normalized)) errors.push(`${name}_INVALID`);
+}
+
+function containsPlaceholder(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return forbiddenFragments.some((fragment) => normalized.includes(fragment));
+}

--- a/blue-cat-landing/src/lib/safe-error.test.ts
+++ b/blue-cat-landing/src/lib/safe-error.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { safeErrorCode } from "./safe-error";
+
+describe("safeErrorCode", () => {
+  it("preserves the public commerce gate code", () => {
+    expect(safeErrorCode(new Error("COMMERCE_NOT_ENABLED"))).toBe("COMMERCE_NOT_ENABLED");
+  });
+
+  it("does not expose unexpected internal messages", () => {
+    expect(safeErrorCode(new Error("database host and password leaked"))).toBe("Error");
+  });
+});

--- a/blue-cat-landing/src/lib/safe-error.ts
+++ b/blue-cat-landing/src/lib/safe-error.ts
@@ -5,6 +5,7 @@ const internalCodes = new Set([
   "INVALID_REVIEW_TRANSITION", "PAYMENT_MISMATCH_REQUIRES_NOTE", "INVALID_QUOTE_STATE",
   "INVALID_STORAGE_KEY",
   "EVIDENCE_DIR_INVALID",
+  "COMMERCE_NOT_ENABLED",
 ]);
 
 export function safeErrorCode(error: unknown): string {


### PR DESCRIPTION
## Resultado

Prepara un staging reproducible y aislado para la landing y el portal comercial. El ERP/POS local no forma parte del contexto Docker ni de la red pública.

## Incluye

- runtime y migrador Docker separados, ejecutados como usuario no root
- Caddy como único servicio público; MySQL y worker en red interna
- preflight que bloquea HTTP, localhost, secretos débiles/repetidos, indexación y comercio real
- imágenes inmutables en GHCR con SBOM y provenance
- liveness/readiness y smoke de 14 controles
- noindex para staging
- migraciones sin permiso global para crear bases
- runbook de backup cifrado, migración, rollback y monitoreo
- checklist E2E completo, incluyendo la frontera del ERP/POS
- corrección del gate comercial para responder 503 en vez de 500

## Validación local

- lint: OK
- TypeScript: OK
- 29 tests: OK
- build Next.js: OK
- npm audit: 0 vulnerabilidades
- migración inicial e idempotente: OK
- preflight staging: OK
- smoke local (14 checks): OK
- baseline PHP y security baseline: OK
- YAML workflows/compose: OK

Docker no está instalado en la estación Windows; el workflow `Staging readiness` construye ambos targets en Linux antes de fusionar.