### PR TITLE
fix: remove @vercel/static and use default static serving for public directory

### DIFF
--- a/license-manager/vercel.json
+++ b/license-manager/vercel.json
@@ -4,10 +4,6 @@
     {
       "src": "server.js",
       "use": "@vercel/node"
-    },
-    {
-      "src": "public/**",
-      "use": "@vercel/static"
     }
   ],
   "routes": [
@@ -16,8 +12,16 @@
       "dest": "server.js"
     },
     {
+      "src": "/styles.css",
+      "dest": "public/styles.css"
+    },
+    {
+      "src": "/app.js",
+      "dest": "public/app.js"
+    },
+    {
       "src": "/(.*)",
-      "dest": "public/$1"
+      "dest": "public/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Objetivo
Corregir definitivamente el error 404 NOT_FOUND en el despliegue del panel administrador de license-manager.

## Cambios
1. Se removió el builder @vercel/static de vercel.json ya que en las nuevas versiones de Vercel causa que los assets se compilen en la raíz (removiendo el prefijo public/), lo que rompía las rutas de destino de nuestra CDN.
2. Al mantener solo el builder @vercel/node para server.js, Vercel despliega automáticamente los archivos estáticos de la carpeta public por defecto manteniendo el prefijo public/.
3. Esto permite que las reglas explícitas de SPA y estáticos de vercel.json enruten /styles.css y /app.js de forma correcta.