### PR TITLE
fix: combine @vercel/static with explicit index.html routing

### DIFF
--- a/license-manager/vercel.json
+++ b/license-manager/vercel.json
@@ -4,6 +4,10 @@
     {
       "src": "server.js",
       "use": "@vercel/node"
+    },
+    {
+      "src": "public/**",
+      "use": "@vercel/static"
     }
   ],
   "routes": [


### PR DESCRIPTION
## Objetivo
Corregir de forma absoluta el error 404 NOT_FOUND en el despliegue del panel administrador de license-manager en Vercel.

## Cambios
1. Se reincorporó el builder @vercel/static para public/** en vercel.json para garantizar que Vercel compile y suba la carpeta public como assets del despliegue.
2. Se configuraron rutas de redirección deterministas apuntando a los archivos físicos (ej. public/index.html para la raíz / en lugar de una carpeta public/), lo que previene que la CDN de Vercel lance un error 404 por falta de indexación de directorios en builders heredados.