### PR TITLE
fix: resolve JavaScript syntax error in public/app.js

### DIFF
--- a/license-manager/public/app.js
+++ b/license-manager/public/app.js
@@ -515,6 +515,12 @@ document.addEventListener('DOMContentLoaded', () => {
       changePassSuccess.textContent = data.message;
       changePassSuccess.classList.remove('hidden');
       setTimeout(closePassModal, 1500);
+    } catch (err) {
+      changePassError.textContent = err.message;
+      changePassError.classList.remove('hidden');
+    }
+  });
+
   // Copiar Enlace Directo del Instalador EXE
   window.copyInstallerLink = () => {
     const url = `${window.location.origin}/api/download/bluecat-installer`;
@@ -524,8 +530,6 @@ document.addEventListener('DOMContentLoaded', () => {
       prompt('Copia el enlace de descarga para enviarlo al cliente:', url);
     });
   };
-    }
-  });
 
   // Enviar Licencia por Correo
   window.sendEmailToClient = async (licenseId, defaultEmail) => {


### PR DESCRIPTION
## Objetivo
Corregir un error de sintaxis en public/app.js del administrador de licencias (license-manager), el cual provocaba que el script del frontend crasheara durante la carga y la acción de inicio de sesión recargara la página.

## Cambios
1. Se restituyó el bloque catch (err) faltante en el listener de envío del formulario de cambio de contraseña (formChangePass).
2. Se extrajo la función global window.copyInstallerLink fuera de dicho listener de formulario, ubicándola a nivel del callback de DOMContentLoaded principal para evitar anidamientos de try/catch rotos.