### PR TITLE
fix: remove default credentials hint from frontend

### DIFF
--- a/license-manager/public/index.html
+++ b/license-manager/public/index.html
@@ -33,7 +33,7 @@
       <form id="login-form">
         <div class="form-group">
           <label for="login-username"><i class="ri-user-line"></i> Usuario Administrador</label>
-          <input type="text" id="login-username" placeholder="admin" required autocomplete="username">
+          <input type="text" id="login-username" placeholder="Usuario" required autocomplete="username">
         </div>
 
         <div class="form-group">
@@ -51,10 +51,6 @@
         <button type="submit" class="btn btn-primary btn-block">
           <i class="ri-login-box-line"></i> Iniciar Sesión en el Panel
         </button>
-
-        <div class="credentials-hint">
-          <i class="ri-information-line"></i> Credenciales por defecto: <strong>admin</strong> / <strong>admin123</strong>
-        </div>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Objetivo
Remover las leyendas y placeholders informativos sobre el usuario/contraseña por defecto en la pantalla de login del panel administrador, previniendo fugas de información.

## Cambios
1. Se eliminó la etiqueta `<div class="credentials-hint">` que mostraba las credenciales `admin` / `admin123` en el archivo `public/index.html`.
2. Se cambió el placeholder del campo de usuario de `admin` a `Usuario`.
