### PR TITLE
fix: prefix tables with licensing schema for Supabase pooler

### DIFF
--- a/license-manager/db.js
+++ b/license-manager/db.js
@@ -40,6 +40,9 @@ function translateSql(sql) {
     translated = 'INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value';
   }
   
+  // Agregar prefijo de esquema 'licensing.' a todas las tablas conocidas
+  translated = translated.replace(/(?<!licensing\.)\b(admins|clients|licenses|sessions|settings)\b/g, 'licensing.$1');
+
   return translated;
 }
 

--- a/license-manager/server.js
+++ b/license-manager/server.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const db = require('./db');
 
 const app = express();
+app.set('trust proxy', 1);
 const PORT = process.env.PORT || 3050;
 const JWT_SECRET = process.env.JWT_SECRET || 'antigravity_license_secret_key_2026_super_secure';
 


### PR DESCRIPTION
## Objetivo
Resolver el error de base de datos `relation "admins" does not exist` y quitar las advertencias de cabecera `Forwarded` en Vercel.

## Cambios
1. **Traducción SQL**: Se actualizó `translateSql` en `db.js` para anteponer automáticamente el prefijo del esquema `licensing.` a los nombres de las tablas. Esto es crucial debido a que el Connection Pooler (Supavisor) de Supabase en modo **Transaction** ignora o resetea el parámetro de conexión `options=-csearch_path=licensing`.
2. **Confianza de Proxy**: Se agregó `app.set('trust proxy', 1)` en `server.js` para que Express y `express-rate-limit` confíen en las cabeceras inversas que inyecta Vercel (`X-Forwarded-For`), silenciando las advertencias y validando correctamente las IPs.
