### PR TITLE
fix: secure admin setup and SMTP persistence

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -30,6 +30,8 @@ jobs:
         run: php Blue-Cat/scripts/test-sales-immutability-ui.php
       - name: Inventory UI preserves decimal quantities
         run: php Blue-Cat/scripts/test-inventory-ui-contract.php
+      - name: License manager security contract
+        run: node license-manager/test_security_contract.js
       - name: Secret patterns
         shell: bash
         run: |

--- a/license-manager/db.js
+++ b/license-manager/db.js
@@ -35,11 +35,6 @@ function translateSql(sql) {
   translated = translated.replace(/datetime\(s\.last_heartbeat\)/gi, 's.last_heartbeat');
   translated = translated.replace(/datetime\('now',\s*'-2 minutes'\)/gi, "NOW() - INTERVAL '2 minutes'");
   
-  // Reemplazar INSERT OR REPLACE
-  if (translated.toUpperCase().includes('INSERT OR REPLACE INTO settings')) {
-    translated = 'INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value';
-  }
-  
   // Agregar prefijo de esquema 'licensing.' a todas las tablas conocidas
   translated = translated.replace(/(?<!licensing\.)\b(admins|clients|licenses|sessions|settings)\b/g, 'licensing.$1');
 

--- a/license-manager/server.js
+++ b/license-manager/server.js
@@ -67,22 +67,6 @@ function authAdminMiddleware(req, res, next) {
 // RUTAS DEL PANEL DE ADMINISTRACIÓN
 // ==========================================
 
-// Ruta temporal para inicializar/restablecer credenciales de admin vía body (POST)
-app.post('/api/admin/setup', (req, res) => {
-  const username = req.body.username || 'admin';
-  const password = req.body.password || 'admin123';
-  const hash = bcrypt.hashSync(password, 10);
-  
-  db.run(`DELETE FROM admins WHERE username = ?`, [username], (delErr) => {
-    db.run(`INSERT INTO admins (username, password_hash) VALUES (?, ?)`, [username, hash], (insErr) => {
-      if (insErr) {
-        return res.status(500).json({ error: 'Error al inicializar admin: ' + insErr.message });
-      }
-      res.json({ message: 'Credenciales de administrador inicializadas con éxito.', username });
-    });
-  });
-});
-
 // Login de Admin
 app.post('/api/admin/login', (req, res) => {
   const { username, password } = req.body;

--- a/license-manager/server.js
+++ b/license-manager/server.js
@@ -589,7 +589,7 @@ app.get('/api/admin/smtp-settings', authAdminMiddleware, (req, res) => {
 
 app.post('/api/admin/smtp-settings', authAdminMiddleware, (req, res) => {
   const { host, port, user, pass, from } = req.body;
-  const stmt = db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`);
+  const stmt = db.prepare(`INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`);
 
   stmt.run('smtp_host', host || '');
   stmt.run('smtp_port', port || '587');

--- a/license-manager/test_security_contract.js
+++ b/license-manager/test_security_contract.js
@@ -2,11 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 const serverPath = path.join(__dirname, 'server.js');
+const dbPath = path.join(__dirname, 'db.js');
 const serverSource = fs.readFileSync(serverPath, 'utf8');
+const dbSource = fs.readFileSync(dbPath, 'utf8');
 
 if (serverSource.includes('/api/admin/setup')) {
   console.error('Security contract failed: public admin setup endpoint is present.');
   process.exit(1);
 }
 
-console.log('Security contract passed: no public admin setup endpoint.');
+if (serverSource.includes('INSERT OR REPLACE') || dbSource.includes('INSERT OR REPLACE')) {
+  console.error('Database contract failed: SQLite INSERT OR REPLACE syntax is present.');
+  process.exit(1);
+}
+
+console.log('Security contract passed: no public admin setup endpoint or SQLite upsert syntax.');

--- a/license-manager/test_security_contract.js
+++ b/license-manager/test_security_contract.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const serverPath = path.join(__dirname, 'server.js');
+const serverSource = fs.readFileSync(serverPath, 'utf8');
+
+if (serverSource.includes('/api/admin/setup')) {
+  console.error('Security contract failed: public admin setup endpoint is present.');
+  process.exit(1);
+}
+
+console.log('Security contract passed: no public admin setup endpoint.');


### PR DESCRIPTION
Elimina el endpoint no autenticado POST /api/admin/setup, reemplaza la sintaxis SQLite INSERT OR REPLACE por un UPSERT nativo de PostgreSQL para guardar SMTP y añade una prueba de contrato al workflow baseline. Verificado localmente con sintaxis Node, contrato de seguridad, baseline y contratos de ventas e inventario.