### PR TITLE
fix: habilitar acceso al portal con Supabase pooler

### DIFF
--- a/blue-cat-landing/.env.example
+++ b/blue-cat-landing/.env.example
@@ -10,9 +10,9 @@ INSTALLER_VERSION=
 APP_ENV=development
 DEPLOYMENT_COMMIT=
 PUBLIC_INDEXING_ENABLED=false
-DATABASE_URL=mysql://root@127.0.0.1:3306/blue_cat_commercial
-DATABASE_TIMEZONE=local
-DATABASE_CREATE_ALLOWED=true
+# En Vercel use el pooler de Supabase (puerto 6543), no db.PROJECT_REF.supabase.co.
+DATABASE_URL=postgresql://postgres.PROJECT_REF:ENCODED_PASSWORD@aws-0-REGION.pooler.supabase.com:6543/postgres
+DATABASE_CREATE_ALLOWED=false
 # Identidad: genere valores aleatorios antes de habilitar el portal.
 # IDENTITY_DATA_KEY debe ser exactamente 32 bytes codificados en Base64.
 IDENTITY_DATA_KEY=

--- a/blue-cat-landing/README.md
+++ b/blue-cat-landing/README.md
@@ -22,7 +22,7 @@ Abre `http://localhost:3000`. Laragon es opcional: Next.js se ejecuta con Node y
 
 Antes de migrar, configura en `.env.local`:
 
-- `DATABASE_URL`: base exclusiva del portal.
+- `DATABASE_URL`: conexión PostgreSQL. En Supabase desplegado usa el pooler (puerto 6543), nunca el host directo `db.PROJECT_REF.supabase.co`; el portal mantiene sus tablas en el esquema `landing`.
 - `IDENTITY_DATA_KEY`: exactamente 32 bytes codificados en Base64.
 - `IDENTITY_HASH_PEPPER`: secreto aleatorio de 32 caracteres o más.
 - `OUTBOX_WORKER_TOKEN`: secreto aleatorio de 32 caracteres o más.

--- a/blue-cat-landing/scripts/bootstrap-operator.ts
+++ b/blue-cat-landing/scripts/bootstrap-operator.ts
@@ -18,7 +18,7 @@ async function main() {
   try {
     await connection.query("BEGIN");
     const result = await connection.query<{ id: string; user_type: string }>(
-      "SELECT id,user_type FROM portal_users WHERE normalized_email=$1 LIMIT 1 FOR UPDATE",
+      "SELECT id,user_type FROM landing.portal_users WHERE normalized_email=$1 LIMIT 1 FOR UPDATE",
       [normalizedEmail],
     );
     const existing = result.rows[0];
@@ -26,26 +26,26 @@ async function main() {
     const userId = existing?.id || randomUUID();
     if (existing) {
       await connection.query(
-        `UPDATE portal_users
+        `UPDATE landing.portal_users
          SET email=$1,display_name=$2,password_hash=$3,status='active',email_verified_at=COALESCE(email_verified_at,CURRENT_TIMESTAMP),
              password_changed_at=CURRENT_TIMESTAMP,session_version=session_version+1,mfa_required=true
          WHERE id=$4`,
         [emailInput, name, passwordHash, userId],
       );
       await connection.query(
-        "UPDATE portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason='OPERATOR_BOOTSTRAP' WHERE user_id=$1 AND revoked_at IS NULL",
+        "UPDATE landing.portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason='OPERATOR_BOOTSTRAP' WHERE user_id=$1 AND revoked_at IS NULL",
         [userId],
       );
     } else {
       await connection.query(
-        `INSERT INTO portal_users
+        `INSERT INTO landing.portal_users
           (id,email,normalized_email,display_name,password_hash,user_type,status,email_verified_at,mfa_required)
          VALUES ($1,$2,$3,$4,$5,'operator','active',CURRENT_TIMESTAMP,true)`,
         [userId, emailInput, normalizedEmail, name, passwordHash],
       );
     }
     await connection.query(
-      `INSERT INTO audit_events
+      `INSERT INTO landing.audit_events
         (request_id,aggregate_type,aggregate_id,event_type,metadata_json)
        VALUES ($1,'portal_user',$2,'operator_bootstrapped',$3)`,
       [randomUUID(), userId, JSON.stringify({ email: normalizedEmail, existing: Boolean(existing) })],

--- a/blue-cat-landing/scripts/test-identity-flow.ts
+++ b/blue-cat-landing/scripts/test-identity-flow.ts
@@ -38,12 +38,12 @@ async function main() {
   assert.ok(registered.userId && registered.verificationToken);
 
   const usersResult = await getPool().query<{ password_hash: string; status: string }>(
-    "SELECT password_hash,status FROM portal_users WHERE id=$1",
+    "SELECT password_hash,status FROM landing.portal_users WHERE id=$1",
     [registered.userId],
   );
   assert.equal(usersResult.rows[0]?.status, "pending_verification");
   assert.equal(isArgon2idHash(usersResult.rows[0]?.password_hash || ""), true);
-  const outboxResult = await getPool().query<{ encrypted_payload: string }>("SELECT encrypted_payload FROM email_outbox LIMIT 1");
+  const outboxResult = await getPool().query<{ encrypted_payload: string }>("SELECT encrypted_payload FROM landing.email_outbox LIMIT 1");
   assert.equal(outboxResult.rows[0]?.encrypted_payload.includes(registered.verificationToken!), false, "Raw tokens must not be stored in outbox payloads.");
 
   assert.equal(await verifyPortalEmail(registered.verificationToken!, randomUUID()), true);
@@ -79,7 +79,7 @@ async function main() {
   assert.equal(await resetPortalPassword(reset.resetToken!, "BlueCat-New!2026", randomUUID()), true);
   assert.equal(await authenticatePortalRequest(authenticatedRequest), null, "Password reset revokes prior sessions.");
 
-  await getPool().query("UPDATE portal_users SET user_type='operator',mfa_required=true WHERE id=$1", [registered.userId]);
+  await getPool().query("UPDATE landing.portal_users SET user_type='operator',mfa_required=true WHERE id=$1", [registered.userId]);
   const operatorLogin = await loginPortal({ email, password: "BlueCat-New!2026" }, request, randomUUID());
   assert.equal(operatorLogin.status, "authenticated");
   if (operatorLogin.status !== "authenticated") throw new Error("OPERATOR_LOGIN_FAILED");

--- a/blue-cat-landing/src/app/globals.css
+++ b/blue-cat-landing/src/app/globals.css
@@ -51,7 +51,10 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .header-row { display: flex; min-height: 4.75rem; align-items: center; gap: 1.4rem; }
 .brand { display: inline-flex; align-items: center; gap: .68rem; font-weight: 790; letter-spacing: -.025em; }
 .brand img { width: 2.35rem; height: 2.35rem; object-fit: contain; }
-.desktop-nav { display: flex; align-items: center; gap: 1.35rem; margin-left: auto; }
+.desktop-nav { display: flex; align-items: center; gap: 1rem; margin-left: auto; }
+.header-auth { display: flex; align-items: center; gap: .8rem; padding-left: .15rem; }
+.header-auth a:last-child { color: var(--blue); }
+.desktop-nav .button { min-height: 2.8rem; padding: .72rem 1rem; }
 .desktop-nav a { color: #405066; font-size: .93rem; font-weight: 650; }
 .desktop-nav a:hover { color: var(--blue); }
 .menu-button { display: none; margin-left: auto; width: 2.75rem; height: 2.75rem; align-items: center; justify-content: center; border: 1px solid var(--line); border-radius: .75rem; background: white; }

--- a/blue-cat-landing/src/components/layout/site-header.tsx
+++ b/blue-cat-landing/src/components/layout/site-header.tsx
@@ -17,7 +17,10 @@ export function SiteHeader() {
         </Link>
         <nav className="desktop-nav" aria-label="Navegación principal">
           {navigation.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}
-          <Link href="/ingresar">Portal</Link>
+          <div className="header-auth" role="group" aria-label="Acceso de clientes">
+            <Link href="/ingresar">Iniciar sesión</Link>
+            <Link href="/crear-cuenta">Crear cuenta</Link>
+          </div>
           <Link className="button button-primary" href="/comprar">Solicitar licencia</Link>
         </nav>
         <button className="menu-button" type="button" onClick={() => setOpen((value) => !value)} aria-expanded={open} aria-controls="mobile-navigation" aria-label={open ? "Cerrar menú" : "Abrir menú"}>
@@ -26,7 +29,8 @@ export function SiteHeader() {
       </div>
       <nav id="mobile-navigation" className={`container mobile-nav ${open ? "open" : ""}`} aria-label="Navegación móvil">
         {navigation.map((item) => <Link key={item.href} href={item.href} onClick={() => setOpen(false)}>{item.label}</Link>)}
-        <Link href="/ingresar" onClick={() => setOpen(false)}>Portal de clientes</Link>
+        <Link href="/ingresar" onClick={() => setOpen(false)}>Iniciar sesión</Link>
+        <Link href="/crear-cuenta" onClick={() => setOpen(false)}>Crear cuenta</Link>
         <Link href="/comprar" onClick={() => setOpen(false)}>Solicitar licencia</Link>
       </nav>
     </header>

--- a/blue-cat-landing/src/config/runtime-environment.test.ts
+++ b/blue-cat-landing/src/config/runtime-environment.test.ts
@@ -77,4 +77,12 @@ describe("validateStagingEnvironment", () => {
       "STAGING_SECRETS_MUST_BE_UNIQUE",
     ]));
   });
+
+  it("rejects direct Supabase database hosts in deployed environments", () => {
+    const environment = validEnvironment();
+    environment.DATABASE_URL = `postgresql://postgres:${"d".repeat(40)}@db.ujrgeegybvibtjqxnxna.supabase.co:5432/postgres`;
+    const result = validateStagingEnvironment(environment);
+
+    expect(result.errors).toContain("DATABASE_URL_MUST_USE_SUPABASE_POOLER");
+  });
 });

--- a/blue-cat-landing/src/config/runtime-environment.ts
+++ b/blue-cat-landing/src/config/runtime-environment.ts
@@ -93,6 +93,9 @@ function validateDatabaseUrl(value: string | undefined, errors: string[]): void 
       errors.push("DATABASE_URL_MISSING_CREDENTIALS_OR_DATABASE");
     }
     if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) errors.push("DATABASE_URL_MUST_NOT_BE_LOCALHOST");
+    if (url.hostname.startsWith("db.") && url.hostname.endsWith(".supabase.co")) {
+      errors.push("DATABASE_URL_MUST_USE_SUPABASE_POOLER");
+    }
   } catch {
     errors.push("DATABASE_URL_INVALID");
   }

--- a/blue-cat-landing/src/infrastructure/database/postgres.ts
+++ b/blue-cat-landing/src/infrastructure/database/postgres.ts
@@ -19,16 +19,7 @@ function createPool(): Pool {
 
 export function getPool(): Pool {
   if (!globalDatabase.blueCatPool) {
-    const pool = createPool();
-    
-    // Configurar el esquema landing automáticamente para todas las conexiones del pool
-    pool.on('connect', (client) => {
-      client.query('SET search_path TO landing').catch(err => {
-        console.error("Error al establecer search_path en la conexión:", err);
-      });
-    });
-    
-    globalDatabase.blueCatPool = pool;
+    globalDatabase.blueCatPool = createPool();
   }
   return globalDatabase.blueCatPool;
 }

--- a/blue-cat-landing/src/infrastructure/database/schema-qualification.test.ts
+++ b/blue-cat-landing/src/infrastructure/database/schema-qualification.test.ts
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const landingTables = [
+  "customers",
+  "purchase_requests",
+  "audit_events",
+  "payment_reports",
+  "api_rate_limits",
+  "portal_users",
+  "portal_email_tokens",
+  "portal_sessions",
+  "organizations",
+  "organization_memberships",
+  "organization_billing_profiles",
+  "portal_consents",
+  "email_outbox",
+  "admin_sessions",
+  "customer_email_verifications",
+  "product_artifacts",
+  "licenses",
+  "license_challenges",
+  "license_leases",
+  "download_grants",
+];
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.isFile() && /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+}
+
+describe("PostgreSQL schema qualification", () => {
+  it("qualifies every landing table used by runtime SQL", () => {
+    const sourceRoots = ["src", "scripts"].map((directory) => join(process.cwd(), directory));
+    const unqualifiedTable = new RegExp(
+      `\\b(?:FROM|JOIN|UPDATE|INTO)\\s+(?:${landingTables.join("|")})\\b`,
+      "gi",
+    );
+    const failures = sourceRoots.flatMap(sourceFiles).flatMap((path) => {
+      const matches = readFileSync(path, "utf8").match(unqualifiedTable) ?? [];
+      return matches.map((match) => `${path}: ${match}`);
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  it("does not rely on an asynchronous search_path hook", () => {
+    const adapter = readFileSync(join(process.cwd(), "src/infrastructure/database/postgres.ts"), "utf8");
+    expect(adapter).not.toContain("SET search_path");
+  });
+});

--- a/blue-cat-landing/src/lib/http-security.ts
+++ b/blue-cat-landing/src/lib/http-security.ts
@@ -23,12 +23,12 @@ export async function enforceRateLimit(scope: string, identifier: string, maximu
   const expiresAt = new Date((windowNumber + 1) * windowSeconds * 1000);
   
   await pool.query(
-    "INSERT INTO api_rate_limits (scope, key_hash, request_count, expires_at) VALUES ($1, $2, 1, $3) ON CONFLICT (scope, key_hash) DO UPDATE SET request_count = api_rate_limits.request_count + 1",
+    "INSERT INTO landing.api_rate_limits (scope, key_hash, request_count, expires_at) VALUES ($1, $2, 1, $3) ON CONFLICT (scope, key_hash) DO UPDATE SET request_count = api_rate_limits.request_count + 1",
     [scope, keyHash, expiresAt],
   );
   
   const result = await pool.query<{ request_count: number }>(
-    "SELECT request_count FROM api_rate_limits WHERE scope = $1 AND key_hash = $2 LIMIT 1",
+    "SELECT request_count FROM landing.api_rate_limits WHERE scope = $1 AND key_hash = $2 LIMIT 1",
     [scope, keyHash],
   );
   

--- a/blue-cat-landing/src/modules/admin/infrastructure/mysql-admin-session-repository.ts
+++ b/blue-cat-landing/src/modules/admin/infrastructure/mysql-admin-session-repository.ts
@@ -31,7 +31,7 @@ export async function createAdminSession(input: { actor: string; email: string; 
   const hours = Number.isFinite(configuredHours) ? Math.min(24, Math.max(1, configuredHours)) : 12;
   const expiresAt = new Date(Date.now() + hours * 3_600_000);
   await getPool().query(
-    "INSERT INTO admin_sessions (id, actor_id, email, token_hash, csrf_token_hash, client_key_hash, expires_at) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    "INSERT INTO landing.admin_sessions (id, actor_id, email, token_hash, csrf_token_hash, client_key_hash, expires_at) VALUES ($1, $2, $3, $4, $5, $6, $7)",
     [randomUUID(), input.actor, input.email, opaqueTokenHash(token), opaqueTokenHash(csrfToken), opaqueTokenHash(input.clientKey), expiresAt],
   );
   return { token, csrfToken, expiresAt };
@@ -40,17 +40,17 @@ export async function createAdminSession(input: { actor: string; email: string; 
 export async function findAdminSession(rawToken: string): Promise<AdminSession | null> {
   if (!/^[A-Za-z0-9_-]{40,60}$/.test(rawToken)) return null;
   const result = await getPool().query<AdminSessionRow>(
-    "SELECT id, actor_id, email, csrf_token_hash, expires_at FROM admin_sessions WHERE token_hash = $1 AND revoked_at IS NULL AND expires_at > CURRENT_TIMESTAMP LIMIT 1",
+    "SELECT id, actor_id, email, csrf_token_hash, expires_at FROM landing.admin_sessions WHERE token_hash = $1 AND revoked_at IS NULL AND expires_at > CURRENT_TIMESTAMP LIMIT 1",
     [opaqueTokenHash(rawToken)],
   );
   const row = result.rows[0];
   if (!row) return null;
-  void getPool().query("UPDATE admin_sessions SET last_seen_at = CURRENT_TIMESTAMP WHERE id = $1", [row.id]).catch(() => undefined);
+  void getPool().query("UPDATE landing.admin_sessions SET last_seen_at = CURRENT_TIMESTAMP WHERE id = $1", [row.id]).catch(() => undefined);
   return { id: row.id, actor: row.actor_id, email: row.email, csrfTokenHash: row.csrf_token_hash, expiresAt: row.expires_at };
 }
 
 export async function revokeAdminSession(rawToken: string): Promise<void> {
   if (!rawToken) return;
-  await getPool().query("UPDATE admin_sessions SET revoked_at = CURRENT_TIMESTAMP WHERE token_hash = $1 AND revoked_at IS NULL", [opaqueTokenHash(rawToken)]);
+  await getPool().query("UPDATE landing.admin_sessions SET revoked_at = CURRENT_TIMESTAMP WHERE token_hash = $1 AND revoked_at IS NULL", [opaqueTokenHash(rawToken)]);
 }
 

--- a/blue-cat-landing/src/modules/identity/application/identity-service.ts
+++ b/blue-cat-landing/src/modules/identity/application/identity-service.ts
@@ -66,7 +66,7 @@ export async function registerPortalAccount(
   try {
     await connection.query("BEGIN");
     const existingResult = await connection.query<UserRow>(
-      "SELECT id,status FROM portal_users WHERE normalized_email=$1 LIMIT 1 FOR UPDATE",
+      "SELECT id,status FROM landing.portal_users WHERE normalized_email=$1 LIMIT 1 FOR UPDATE",
       [email],
     );
     const existing = existingResult.rows;
@@ -75,7 +75,7 @@ export async function registerPortalAccount(
       return { accepted: true };
     }
     await connection.query(
-      `INSERT INTO portal_users
+      `INSERT INTO landing.portal_users
         (id,email,normalized_email,display_name,password_hash,user_type,status)
        VALUES ($1,$2,$3,$4,$5,'customer','pending_verification')`,
       [userId, input.email.trim(), email, input.displayName, passwordHash],
@@ -84,7 +84,7 @@ export async function registerPortalAccount(
     await recordConsent(connection, userId, "privacy", input.privacyVersion, true, request);
     await recordConsent(connection, userId, "marketing", marketingVersion(), input.marketingConsent, request);
     await connection.query(
-      `INSERT INTO portal_email_tokens (id,user_id,token_type,token_hash,expires_at)
+      `INSERT INTO landing.portal_email_tokens (id,user_id,token_type,token_hash,expires_at)
        VALUES ($1,$2,'verify_email',$3,$4)`,
       [randomUUID(), userId, tokenHash, expiresAt],
     );
@@ -122,7 +122,7 @@ export async function resendVerificationEmail(
 ): Promise<{ accepted: true; verificationToken?: string }> {
   const email = normalizeEmail(emailInput);
   const result = await getPool().query<UserRow>(
-    "SELECT * FROM portal_users WHERE normalized_email=$1 LIMIT 1",
+    "SELECT * FROM landing.portal_users WHERE normalized_email=$1 LIMIT 1",
     [email],
   );
   const user = result.rows[0];
@@ -134,11 +134,11 @@ export async function resendVerificationEmail(
   try {
     await connection.query("BEGIN");
     await connection.query(
-      "UPDATE portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE user_id=$1 AND token_type='verify_email' AND used_at IS NULL",
+      "UPDATE landing.portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE user_id=$1 AND token_type='verify_email' AND used_at IS NULL",
       [user.id],
     );
     await connection.query(
-      "INSERT INTO portal_email_tokens (id,user_id,token_type,token_hash,expires_at) VALUES ($1,$2,'verify_email',$3,CURRENT_TIMESTAMP + INTERVAL '24 hours')",
+      "INSERT INTO landing.portal_email_tokens (id,user_id,token_type,token_hash,expires_at) VALUES ($1,$2,'verify_email',$3,CURRENT_TIMESTAMP + INTERVAL '24 hours')",
       [randomUUID(), user.id, tokenHash],
     );
     await queueEmail(connection, {
@@ -169,7 +169,7 @@ export async function verifyPortalEmail(token: string, requestId: string): Promi
     await connection.query("BEGIN");
     const result = await connection.query<TokenRow>(
       `SELECT id,user_id,expires_at
-       FROM portal_email_tokens
+       FROM landing.portal_email_tokens
        WHERE token_hash=$1 AND token_type='verify_email' AND used_at IS NULL
        LIMIT 1 FOR UPDATE`,
       [hashToken(token)],
@@ -179,9 +179,9 @@ export async function verifyPortalEmail(token: string, requestId: string): Promi
       await connection.query("ROLLBACK");
       return false;
     }
-    await connection.query("UPDATE portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE id=$1", [row.id]);
+    await connection.query("UPDATE landing.portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE id=$1", [row.id]);
     await connection.query(
-      `UPDATE portal_users
+      `UPDATE landing.portal_users
        SET status='active',email_verified_at=COALESCE(email_verified_at,CURRENT_TIMESTAMP),
            failed_login_count=0,locked_until=NULL
        WHERE id=$1 AND status<>'disabled'`,
@@ -205,7 +205,7 @@ export async function loginPortal(
 ): Promise<LoginResult> {
   const email = normalizeEmail(input.email);
   const result = await getPool().query<UserRow>(
-    "SELECT * FROM portal_users WHERE normalized_email=$1 LIMIT 1",
+    "SELECT * FROM landing.portal_users WHERE normalized_email=$1 LIMIT 1",
     [email],
   );
   const user = result.rows[0];
@@ -227,7 +227,7 @@ export async function loginPortal(
     authLevel = "mfa";
   }
   await getPool().query(
-    `UPDATE portal_users
+    `UPDATE landing.portal_users
      SET failed_login_count=0,locked_until=NULL,status='active',last_login_at=CURRENT_TIMESTAMP
      WHERE id=$1`,
     [user.id],
@@ -252,7 +252,7 @@ export async function loginPortal(
 export async function issueAccountRecoveryChallenge(emailInput: string, requestId: string): Promise<{ accepted: true; resetToken?: string }> {
   const email = normalizeEmail(emailInput);
   const result = await getPool().query<UserRow>(
-    "SELECT * FROM portal_users WHERE normalized_email=$1 AND status<>'disabled' LIMIT 1",
+    "SELECT * FROM landing.portal_users WHERE normalized_email=$1 AND status<>'disabled' LIMIT 1",
     [email],
   );
   const user = result.rows[0];
@@ -263,11 +263,11 @@ export async function issueAccountRecoveryChallenge(emailInput: string, requestI
   try {
     await connection.query("BEGIN");
     await connection.query(
-      "UPDATE portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE user_id=$1 AND token_type='reset_password' AND used_at IS NULL",
+      "UPDATE landing.portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE user_id=$1 AND token_type='reset_password' AND used_at IS NULL",
       [user.id],
     );
     await connection.query(
-      "INSERT INTO portal_email_tokens (id,user_id,token_type,token_hash,expires_at) VALUES ($1,$2,'reset_password',$3,CURRENT_TIMESTAMP + INTERVAL '30 minutes')",
+      "INSERT INTO landing.portal_email_tokens (id,user_id,token_type,token_hash,expires_at) VALUES ($1,$2,'reset_password',$3,CURRENT_TIMESTAMP + INTERVAL '30 minutes')",
       [randomUUID(), user.id, tokenHash],
     );
     await queueEmail(connection, {
@@ -299,7 +299,7 @@ export async function resetPortalPassword(token: string, password: string, reque
   try {
     await connection.query("BEGIN");
     const result = await connection.query<TokenRow>(
-      `SELECT id,user_id,expires_at FROM portal_email_tokens
+      `SELECT id,user_id,expires_at FROM landing.portal_email_tokens
        WHERE token_hash=$1 AND token_type='reset_password' AND used_at IS NULL
        LIMIT 1 FOR UPDATE`,
       [hashToken(token)],
@@ -310,16 +310,16 @@ export async function resetPortalPassword(token: string, password: string, reque
       return false;
     }
     userId = row.user_id;
-    await connection.query("UPDATE portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE id=$1", [row.id]);
+    await connection.query("UPDATE landing.portal_email_tokens SET used_at=CURRENT_TIMESTAMP WHERE id=$1", [row.id]);
     await connection.query(
-      `UPDATE portal_users
+      `UPDATE landing.portal_users
        SET password_hash=$1,password_changed_at=CURRENT_TIMESTAMP,session_version=session_version+1,
            status=CASE WHEN status='disabled' THEN 'disabled' ELSE 'active' END
        WHERE id=$2`,
       [passwordHash, userId],
     );
     await connection.query(
-      "UPDATE portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason='PASSWORD_RESET' WHERE user_id=$1 AND revoked_at IS NULL",
+      "UPDATE landing.portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason='PASSWORD_RESET' WHERE user_id=$1 AND revoked_at IS NULL",
       [userId],
     );
     await audit(connection, requestId, "portal_user", userId, "password_reset_completed", {});
@@ -337,7 +337,7 @@ export async function beginMfaEnrollment(principal: PortalPrincipal, requestId: 
   if (!principal.emailVerified) throw new Error("EMAIL_NOT_VERIFIED");
   const enrollment = createMfaEnrollment(principal.email);
   await getPool().query(
-    "UPDATE portal_users SET mfa_secret_ciphertext=$1,mfa_recovery_hashes=$2,mfa_enabled=FALSE WHERE id=$3",
+    "UPDATE landing.portal_users SET mfa_secret_ciphertext=$1,mfa_recovery_hashes=$2,mfa_enabled=FALSE WHERE id=$3",
     [enrollment.encryptedSecret, JSON.stringify(enrollment.recoveryHashes), principal.userId],
   );
   await audit(getPool(), requestId, "portal_user", principal.userId, "mfa_enrollment_started", {});
@@ -349,10 +349,10 @@ export async function beginMfaEnrollment(principal: PortalPrincipal, requestId: 
 }
 
 export async function confirmMfaEnrollment(principal: PortalPrincipal, code: string, requestId: string): Promise<boolean> {
-  const result = await getPool().query<UserRow>("SELECT * FROM portal_users WHERE id=$1 LIMIT 1", [principal.userId]);
+  const result = await getPool().query<UserRow>("SELECT * FROM landing.portal_users WHERE id=$1 LIMIT 1", [principal.userId]);
   const user = result.rows[0];
   if (!user?.mfa_secret_ciphertext || !await verifyMfaCode(user.mfa_secret_ciphertext, code)) return false;
-  await getPool().query("UPDATE portal_users SET mfa_enabled=TRUE WHERE id=$1", [principal.userId]);
+  await getPool().query("UPDATE landing.portal_users SET mfa_enabled=TRUE WHERE id=$1", [principal.userId]);
   await revokeAllUserSessions(principal.userId, "MFA_ENABLED");
   await audit(getPool(), requestId, "portal_user", principal.userId, "mfa_enabled", {});
   return true;
@@ -362,7 +362,7 @@ async function registerFailedLogin(user: UserRow, requestId: string): Promise<vo
   const failures = Math.min(20, Number(user.failed_login_count || 0) + 1);
   const lockMinutes = failures >= 5 ? Math.min(60, 15 * Math.max(1, failures - 4)) : 0;
   await getPool().query(
-    `UPDATE portal_users
+    `UPDATE landing.portal_users
      SET failed_login_count=$1,
          locked_until=CASE WHEN $2=0 THEN NULL ELSE CURRENT_TIMESTAMP + ($3 || ' minutes')::interval END,
          status=CASE WHEN $4=0 THEN status ELSE 'locked' END
@@ -385,7 +385,7 @@ async function recordConsent(
     || "unknown";
   const agent = request.headers.get("user-agent")?.slice(0, 512) || "unknown";
   await connection.query(
-    `INSERT INTO portal_consents
+    `INSERT INTO landing.portal_consents
       (id,user_id,consent_type,document_version,granted,ip_hash,user_agent_hash)
      VALUES ($1,$2,$3,$4,$5,$6,$7)`,
     [randomUUID(), userId, type, version, granted, privacyHash(address), privacyHash(agent)],
@@ -404,7 +404,7 @@ async function queueEmail(
 ): Promise<void> {
   const deduplicationKey = hashToken(`${input.template}|${input.userId}|${input.tokenHash}`);
   await connection.query(
-    `INSERT INTO email_outbox
+    `INSERT INTO landing.email_outbox
       (id,user_id,recipient,template_key,encrypted_payload,deduplication_key)
      VALUES ($1,$2,$3,$4,$5,$6)`,
     [
@@ -429,7 +429,7 @@ async function audit(
   metadata: Record<string, unknown>,
 ): Promise<void> {
   await executor.query(
-    `INSERT INTO audit_events
+    `INSERT INTO landing.audit_events
       (request_id,aggregate_type,aggregate_id,event_type,metadata_json)
      VALUES ($1,$2,$3,$4,$5)`,
     [requestId, aggregateType, aggregateId, eventType, JSON.stringify(metadata)],

--- a/blue-cat-landing/src/modules/identity/infrastructure/portal-session.ts
+++ b/blue-cat-landing/src/modules/identity/infrastructure/portal-session.ts
@@ -52,7 +52,7 @@ export async function issuePortalSession(
   const agent = request.headers.get("user-agent")?.slice(0, 512) ?? "unknown";
   
   await getPool().query(
-    `INSERT INTO portal_sessions
+    `INSERT INTO landing.portal_sessions
       (id,user_id,session_token_hash,csrf_token_hash,session_version,auth_level,ip_hash,user_agent_hash,expires_at,idle_expires_at)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     [
@@ -78,8 +78,8 @@ export async function authenticatePortalRequest(request: Request): Promise<Porta
   const result = await getPool().query<SessionRow>(
     `SELECT s.id session_id,s.user_id,u.email,u.display_name,u.user_type,u.status user_status,
       u.email_verified_at,u.mfa_required,u.mfa_enabled,s.auth_level,s.csrf_token_hash
-     FROM portal_sessions s
-     INNER JOIN portal_users u ON u.id=s.user_id
+     FROM landing.portal_sessions s
+     INNER JOIN landing.portal_users u ON u.id=s.user_id
      WHERE s.session_token_hash=$1
        AND s.revoked_at IS NULL
        AND s.expires_at>CURRENT_TIMESTAMP
@@ -93,7 +93,7 @@ export async function authenticatePortalRequest(request: Request): Promise<Porta
   if (!row) return null;
   
   await getPool().query(
-    `UPDATE portal_sessions
+    `UPDATE landing.portal_sessions
      SET last_seen_at=CURRENT_TIMESTAMP,
          idle_expires_at=LEAST(expires_at, CURRENT_TIMESTAMP + INTERVAL '30 minutes')
      WHERE id=$1 AND last_seen_at<CURRENT_TIMESTAMP - INTERVAL '2 minutes'`,
@@ -122,14 +122,14 @@ export function requireRequestCsrf(request: Request, principal: PortalPrincipal)
 
 export async function revokePortalSession(sessionId: string, reason = "LOGOUT"): Promise<void> {
   await getPool().query(
-    "UPDATE portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason=$1 WHERE id=$2 AND revoked_at IS NULL",
+    "UPDATE landing.portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason=$1 WHERE id=$2 AND revoked_at IS NULL",
     [reason, sessionId],
   );
 }
 
 export async function revokeAllUserSessions(userId: string, reason: string): Promise<void> {
   await getPool().query(
-    "UPDATE portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason=$1 WHERE user_id=$2 AND revoked_at IS NULL",
+    "UPDATE landing.portal_sessions SET revoked_at=CURRENT_TIMESTAMP,revoke_reason=$1 WHERE user_id=$2 AND revoked_at IS NULL",
     [reason, userId],
   );
 }

--- a/blue-cat-landing/src/modules/notifications/application/email-outbox-service.ts
+++ b/blue-cat-landing/src/modules/notifications/application/email-outbox-service.ts
@@ -33,7 +33,7 @@ export async function dispatchEmailOutbox(batchSize = 10): Promise<OutboxDispatc
       const message = renderEmail(job.template_key, payload);
       const providerMessageId = await sendEmail(job.recipient, message.subject, message.html, message.text);
       await getPool().query(
-        `UPDATE email_outbox
+        `UPDATE landing.email_outbox
          SET status='sent',provider_message_id=$1,sent_at=CURRENT_TIMESTAMP,
              encrypted_payload='purged',locked_at=NULL,locked_by=NULL,last_error_code=NULL
          WHERE id=$2 AND status='processing'`,
@@ -44,7 +44,7 @@ export async function dispatchEmailOutbox(batchSize = 10): Promise<OutboxDispatc
       const dead = job.attempts >= 5;
       const delayMinutes = Math.min(60, 2 ** Math.max(0, job.attempts - 1));
       await getPool().query(
-        `UPDATE email_outbox
+        `UPDATE landing.email_outbox
          SET status=$1,available_at=CURRENT_TIMESTAMP + ($2 || ' minutes')::interval,
              locked_at=NULL,locked_by=NULL,last_error_code=$3
          WHERE id=$4`,
@@ -64,7 +64,7 @@ async function claimJobs(limit: number): Promise<OutboxRow[]> {
     await connection.query("BEGIN");
     const result = await connection.query<OutboxRow>(
       `SELECT id,recipient,template_key,encrypted_payload,attempts
-       FROM email_outbox
+       FROM landing.email_outbox
        WHERE (
          status IN ('pending','failed') AND available_at<=CURRENT_TIMESTAMP
        ) OR (
@@ -77,7 +77,7 @@ async function claimJobs(limit: number): Promise<OutboxRow[]> {
     const rows = result.rows;
     if (rows.length) {
       await connection.query(
-        `UPDATE email_outbox
+        `UPDATE landing.email_outbox
          SET status='processing',attempts=attempts+1,locked_at=CURRENT_TIMESTAMP,locked_by=$1
          WHERE id = ANY($2::uuid[])`,
         [workerId, rows.map((row) => row.id)],

--- a/blue-cat-landing/src/modules/organizations/application/organization-service.ts
+++ b/blue-cat-landing/src/modules/organizations/application/organization-service.ts
@@ -42,21 +42,21 @@ export async function createOrganization(
   try {
     await connection.query("BEGIN");
     const usersResult = await connection.query<UserStateRow>(
-      "SELECT status,email_verified_at FROM portal_users WHERE id=$1 LIMIT 1 FOR UPDATE",
+      "SELECT status,email_verified_at FROM landing.portal_users WHERE id=$1 LIMIT 1 FOR UPDATE",
       [principal.userId],
     );
     const users = usersResult.rows;
     if (!users[0] || users[0].status !== "active" || !users[0].email_verified_at) throw new Error("VERIFIED_ACCOUNT_REQUIRED");
     
     const countsResult = await connection.query<{ total: string }>(
-      "SELECT COUNT(*)::integer as total FROM organization_memberships WHERE user_id=$1 AND status='active'",
+      "SELECT COUNT(*)::integer as total FROM landing.organization_memberships WHERE user_id=$1 AND status='active'",
       [principal.userId],
     );
     const counts = countsResult.rows;
     if (Number(counts[0]?.total ?? 0) >= 10) throw new Error("ORGANIZATION_LIMIT_REACHED");
     
     await connection.query(
-      `INSERT INTO organizations
+      `INSERT INTO landing.organizations
         (id,slug,legal_name,trading_name,tax_id,country,city,status,created_by)
        VALUES ($1,$2,$3,$4,$5,$6,$7,'active',$8)`,
       [
@@ -71,13 +71,13 @@ export async function createOrganization(
       ],
     );
     await connection.query(
-      `INSERT INTO organization_memberships
+      `INSERT INTO landing.organization_memberships
         (organization_id,user_id,role,status,joined_at)
        VALUES ($1,$2,'owner','active',CURRENT_TIMESTAMP)`,
       [organizationId, principal.userId],
     );
     await connection.query(
-      `INSERT INTO organization_billing_profiles
+      `INSERT INTO landing.organization_billing_profiles
         (organization_id,billing_email,legal_name,tax_id,address_line,city,region,postal_code,country,currency,updated_by)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
       [
@@ -95,7 +95,7 @@ export async function createOrganization(
       ],
     );
     await connection.query(
-      `INSERT INTO audit_events
+      `INSERT INTO landing.audit_events
         (request_id,aggregate_type,aggregate_id,event_type,metadata_json)
        VALUES ($1,'organization',$2,'organization_created',$3)`,
       [requestId, organizationId, JSON.stringify({ actor: principal.userId, slug, country: input.country })],
@@ -116,9 +116,9 @@ export async function getPortalOverview(principal: PortalPrincipal) {
     `SELECT o.id,o.slug,o.legal_name as "legalName",o.trading_name as "tradingName",o.tax_id as "taxId",
       o.country,o.city,o.status,m.role,b.billing_email as "billingEmail",b.address_line as "addressLine",
       b.region,b.postal_code as "postalCode",b.currency
-     FROM organization_memberships m
-     INNER JOIN organizations o ON o.id=m.organization_id
-     LEFT JOIN organization_billing_profiles b ON b.organization_id=o.id
+     FROM landing.organization_memberships m
+     INNER JOIN landing.organizations o ON o.id=m.organization_id
+     LEFT JOIN landing.organization_billing_profiles b ON b.organization_id=o.id
      WHERE m.user_id=$1 AND m.status='active'
      ORDER BY o.created_at ASC`,
     [principal.userId],
@@ -147,7 +147,7 @@ export async function updateBillingProfile(
   requestId: string,
 ): Promise<void> {
   const membershipsResult = await getPool().query<MembershipRow>(
-    `SELECT organization_id,role FROM organization_memberships
+    `SELECT organization_id,role FROM landing.organization_memberships
      WHERE organization_id=$1 AND user_id=$2 AND status='active' LIMIT 1`,
     [organizationId, principal.userId],
   );
@@ -157,7 +157,7 @@ export async function updateBillingProfile(
   try {
     await connection.query("BEGIN");
     await connection.query(
-      `UPDATE organization_billing_profiles
+      `UPDATE landing.organization_billing_profiles
        SET billing_email=$1,legal_name=$2,tax_id=$3,address_line=$4,city=$5,region=$6,postal_code=$7,
            country=$8,currency=$9,updated_by=$10
        WHERE organization_id=$11`,
@@ -176,7 +176,7 @@ export async function updateBillingProfile(
       ],
     );
     await connection.query(
-      `INSERT INTO audit_events
+      `INSERT INTO landing.audit_events
         (request_id,aggregate_type,aggregate_id,event_type,metadata_json)
        VALUES ($1,'organization',$2,'billing_profile_updated',$3)`,
       [requestId, organizationId, JSON.stringify({ actor: principal.userId, currency: input.currency })],

--- a/blue-cat-landing/src/modules/payments/infrastructure/mysql-payment-repository.ts
+++ b/blue-cat-landing/src/modules/payments/infrastructure/mysql-payment-repository.ts
@@ -31,13 +31,13 @@ export async function createPaymentReport(input: PaymentReportInput, evidence: V
   try {
     await connection.query("BEGIN");
     const purchasesResult = await connection.query<PurchaseRow>(
-      "SELECT pr.id, pr.status FROM purchase_requests pr WHERE pr.tracking_id = $1 AND pr.tracking_token_hash = $2 AND pr.tracking_token_expires_at > CURRENT_TIMESTAMP LIMIT 1 FOR UPDATE",
+      "SELECT pr.id, pr.status FROM landing.purchase_requests pr WHERE pr.tracking_id = $1 AND pr.tracking_token_hash = $2 AND pr.tracking_token_expires_at > CURRENT_TIMESTAMP LIMIT 1 FOR UPDATE",
       [input.trackingId, purchaseAccessTokenHash(input.accessToken)],
     );
     const purchase = purchasesResult.rows[0];
     if (!purchase) throw new Error("PURCHASE_NOT_FOUND");
     const existingResult = await connection.query<ExistingPaymentRow>(
-      "SELECT id FROM payment_reports WHERE purchase_request_id = $1 AND evidence_sha256 = $2 LIMIT 1",
+      "SELECT id FROM landing.payment_reports WHERE purchase_request_id = $1 AND evidence_sha256 = $2 LIMIT 1",
       [purchase.id, evidence.sha256],
     );
     if (existingResult.rows[0]) {
@@ -47,12 +47,12 @@ export async function createPaymentReport(input: PaymentReportInput, evidence: V
     if (purchase.status !== "pending_payment") throw new Error("INVALID_PAYMENT_STATE");
     const reportId = randomUUID();
     await connection.query(
-      "INSERT INTO payment_reports (id, purchase_request_id, amount_minor, currency, transfer_date, bank_reference, evidence_storage_key, evidence_original_name, evidence_mime_type, evidence_size_bytes, evidence_sha256, status) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'reported')",
+      "INSERT INTO landing.payment_reports (id, purchase_request_id, amount_minor, currency, transfer_date, bank_reference, evidence_storage_key, evidence_original_name, evidence_mime_type, evidence_size_bytes, evidence_sha256, status) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'reported')",
       [reportId, purchase.id, input.amountMinor, input.currency, input.transferDate, input.bankReference, storageKey, evidence.originalName, evidence.mimeType, evidence.sizeBytes, evidence.sha256],
     );
-    await connection.query("UPDATE purchase_requests SET status = 'payment_reported' WHERE id = $1", [purchase.id]);
+    await connection.query("UPDATE landing.purchase_requests SET status = 'payment_reported' WHERE id = $1", [purchase.id]);
     await connection.query(
-      "INSERT INTO audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'payment_report', $2, 'payment_reported', $3)",
+      "INSERT INTO landing.audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'payment_report', $2, 'payment_reported', $3)",
       [requestId, reportId, JSON.stringify({ trackingId: input.trackingId, amountMinor: input.amountMinor, currency: input.currency, evidenceSha256: evidence.sha256 })],
     );
     await connection.query("COMMIT");
@@ -73,9 +73,9 @@ export async function listPaymentReports(status?: PaymentReportStatus): Promise<
       CAST(pay.amount_minor AS VARCHAR) AS "amountMinor", CAST(pr.expected_amount_minor AS VARCHAR) AS "expectedAmountMinor", pay.currency, TO_CHAR(pay.transfer_date, 'YYYY-MM-DD') AS "transferDate",
       pay.bank_reference AS "bankReference", pay.status, pay.evidence_mime_type AS "mimeType",
       pay.evidence_size_bytes AS "sizeBytes", TO_CHAR(pay.created_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS "createdAt"
-     FROM payment_reports pay
-     INNER JOIN purchase_requests pr ON pr.id = pay.purchase_request_id
-     INNER JOIN customers c ON c.id = pr.customer_id
+     FROM landing.payment_reports pay
+     INNER JOIN landing.purchase_requests pr ON pr.id = pay.purchase_request_id
+     INNER JOIN landing.customers c ON c.id = pr.customer_id
      ${filters}
      ORDER BY pay.created_at ASC LIMIT 100`,
     params,
@@ -85,7 +85,7 @@ export async function listPaymentReports(status?: PaymentReportStatus): Promise<
 
 export async function getPaymentEvidence(reportId: string): Promise<{ storageKey: string; mimeType: string } | null> {
   const result = await getPool().query<EvidenceRow>(
-    "SELECT evidence_storage_key AS storage_key, evidence_mime_type AS mime_type FROM payment_reports WHERE id = $1 LIMIT 1",
+    "SELECT evidence_storage_key AS storage_key, evidence_mime_type AS mime_type FROM landing.payment_reports WHERE id = $1 LIMIT 1",
     [reportId],
   );
   return result.rows[0] ? { storageKey: result.rows[0].storage_key, mimeType: result.rows[0].mime_type } : null;
@@ -96,7 +96,7 @@ export async function reviewPaymentReport(input: PaymentReviewInput, actor: stri
   try {
     await connection.query("BEGIN");
     const result = await connection.query<LockedPaymentRow>(
-      "SELECT pay.id, pay.purchase_request_id, pay.status, CAST(pay.amount_minor AS VARCHAR) AS reported_amount_minor, pay.currency AS reported_currency, CAST(pr.expected_amount_minor AS VARCHAR) AS expected_amount_minor, pr.currency AS expected_currency FROM payment_reports pay INNER JOIN purchase_requests pr ON pr.id = pay.purchase_request_id WHERE pay.id = $1 LIMIT 1 FOR UPDATE",
+      "SELECT pay.id, pay.purchase_request_id, pay.status, CAST(pay.amount_minor AS VARCHAR) AS reported_amount_minor, pay.currency AS reported_currency, CAST(pr.expected_amount_minor AS VARCHAR) AS expected_amount_minor, pr.currency AS expected_currency FROM landing.payment_reports pay INNER JOIN landing.purchase_requests pr ON pr.id = pay.purchase_request_id WHERE pay.id = $1 LIMIT 1 FOR UPDATE",
       [input.reportId],
     );
     const report = result.rows[0];
@@ -107,12 +107,12 @@ export async function reviewPaymentReport(input: PaymentReviewInput, actor: stri
     if (decision === "approved" && amountMismatch && input.note.length < 5) throw new Error("PAYMENT_MISMATCH_REQUIRES_NOTE");
     const purchaseStatus = purchaseStatusForDecision(decision);
     await connection.query(
-      "UPDATE payment_reports SET status = $1, reviewed_by = $2, review_note = $3, reviewed_at = CURRENT_TIMESTAMP WHERE id = $4",
+      "UPDATE landing.payment_reports SET status = $1, reviewed_by = $2, review_note = $3, reviewed_at = CURRENT_TIMESTAMP WHERE id = $4",
       [decision, actor, input.note || null, input.reportId],
     );
-    await connection.query("UPDATE purchase_requests SET status = $1 WHERE id = $2", [purchaseStatus, report.purchase_request_id]);
+    await connection.query("UPDATE landing.purchase_requests SET status = $1 WHERE id = $2", [purchaseStatus, report.purchase_request_id]);
     await connection.query(
-      "INSERT INTO audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'payment_report', $2, $3, $4)",
+      "INSERT INTO landing.audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'payment_report', $2, $3, $4)",
       [requestId, input.reportId, `payment_${decision}`, JSON.stringify({ actor, decision, purchaseStatus, amountMismatch })],
     );
     await connection.query("COMMIT");
@@ -127,7 +127,7 @@ export async function reviewPaymentReport(input: PaymentReviewInput, actor: stri
 
 export async function auditEvidenceAccess(reportId: string, actor: string, requestId: string): Promise<void> {
   await getPool().query(
-    "INSERT INTO audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'payment_report', $2, 'payment_evidence_downloaded', $3)",
+    "INSERT INTO landing.audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'payment_report', $2, 'payment_evidence_downloaded', $3)",
     [requestId, reportId, JSON.stringify({ actor })],
   );
 }

--- a/blue-cat-landing/src/modules/purchases/infrastructure/mysql-purchase-access-repository.ts
+++ b/blue-cat-landing/src/modules/purchases/infrastructure/mysql-purchase-access-repository.ts
@@ -16,7 +16,7 @@ interface QuotePurchaseRow { id: string; status: PurchaseStatus; version: number
 
 export async function getPurchaseStatus(trackingId: string, accessToken: string) {
   const result = await getPool().query<AccessRow>(
-    "SELECT status, expected_amount_minor, currency, offer_version, offer_expires_at, updated_at FROM purchase_requests WHERE tracking_id = $1 AND tracking_token_hash = $2 AND tracking_token_expires_at > CURRENT_TIMESTAMP LIMIT 1",
+    "SELECT status, expected_amount_minor, currency, offer_version, offer_expires_at, updated_at FROM landing.purchase_requests WHERE tracking_id = $1 AND tracking_token_hash = $2 AND tracking_token_expires_at > CURRENT_TIMESTAMP LIMIT 1",
     [trackingId, purchaseAccessTokenHash(accessToken)],
   );
   const row = result.rows[0];
@@ -38,16 +38,16 @@ export async function issuePurchaseQuote(trackingId: string, input: PurchaseQuot
   const connection = await getPool().connect();
   try {
     await connection.query("BEGIN");
-    const result = await connection.query<QuotePurchaseRow>("SELECT id, status, version FROM purchase_requests WHERE tracking_id = $1 LIMIT 1 FOR UPDATE", [trackingId]);
+    const result = await connection.query<QuotePurchaseRow>("SELECT id, status, version FROM landing.purchase_requests WHERE tracking_id = $1 LIMIT 1 FOR UPDATE", [trackingId]);
     const purchase = result.rows[0];
     if (!purchase) throw new Error("PURCHASE_NOT_FOUND");
     if (purchase.status !== "pending_quote") throw new Error("INVALID_QUOTE_STATE");
     await connection.query(
-      "UPDATE purchase_requests SET expected_amount_minor = $1, currency = $2, offer_version = $3, offer_expires_at = $4, status = 'pending_payment', status_changed_at = CURRENT_TIMESTAMP, version = version + 1 WHERE id = $5 AND version = $6",
+      "UPDATE landing.purchase_requests SET expected_amount_minor = $1, currency = $2, offer_version = $3, offer_expires_at = $4, status = 'pending_payment', status_changed_at = CURRENT_TIMESTAMP, version = version + 1 WHERE id = $5 AND version = $6",
       [input.amountMinor, input.currency, input.offerVersion, new Date(input.expiresAt), purchase.id, purchase.version],
     );
     await connection.query(
-      "INSERT INTO audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'purchase_request', $2, 'quote_issued', $3)",
+      "INSERT INTO landing.audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'purchase_request', $2, 'quote_issued', $3)",
       [requestId, trackingId, JSON.stringify({ actor, amountMinor: input.amountMinor, currency: input.currency, offerVersion: input.offerVersion, fromStatus: "pending_quote", toStatus: "pending_payment" })],
     );
     await connection.query("COMMIT");

--- a/blue-cat-landing/src/modules/purchases/infrastructure/mysql-purchase-repository.ts
+++ b/blue-cat-landing/src/modules/purchases/infrastructure/mysql-purchase-repository.ts
@@ -47,7 +47,7 @@ export async function createPurchaseRequest(input: PurchaseRequestInput, request
   try {
     await connection.query("BEGIN");
     const existingResult = await connection.query<ExistingRequestRow>(
-      "SELECT tracking_id, request_hash, status, expected_amount_minor, currency, offer_expires_at FROM purchase_requests WHERE idempotency_key_hash = $1 LIMIT 1",
+      "SELECT tracking_id, request_hash, status, expected_amount_minor, currency, offer_expires_at FROM landing.purchase_requests WHERE idempotency_key_hash = $1 LIMIT 1",
       [idempotencyHash]
     );
     const existing = existingResult.rows;
@@ -57,17 +57,17 @@ export async function createPurchaseRequest(input: PurchaseRequestInput, request
       return existingResultMapping(existing[0], accessToken);
     }
     const customerResult = await connection.query<{ id: string }>(
-      "INSERT INTO customers (business_name, contact_name, email, phone, country, city, tax_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
+      "INSERT INTO landing.customers (business_name, contact_name, email, phone, country, city, tax_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
       [input.businessName, input.contactName, input.email, input.phone, input.country, input.city, input.taxId || null],
     );
     const customerId = customerResult.rows[0].id;
     const id = trackingId();
     await connection.query(
-      "INSERT INTO purchase_requests (tracking_id, customer_id, plan_id, estimated_branches, wants_cloud_sync, message, status, request_hash, idempotency_key_hash, tracking_token_hash, tracking_token_expires_at, expected_amount_minor, currency, offer_version, offer_expires_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+      "INSERT INTO landing.purchase_requests (tracking_id, customer_id, plan_id, estimated_branches, wants_cloud_sync, message, status, request_hash, idempotency_key_hash, tracking_token_hash, tracking_token_expires_at, expected_amount_minor, currency, offer_version, offer_expires_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
       [id, customerId, input.planId, input.estimatedBranches, input.wantsCloudSync, input.message || null, status, hash, idempotencyHash, tokenHash, tokenExpiresAt, offer?.amountMinor ?? null, offer?.currency ?? null, offer?.version ?? null, offer?.expiresAt ?? null],
     );
     await connection.query(
-      "INSERT INTO audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'purchase_request', $2, 'purchase_submitted', $3)",
+      "INSERT INTO landing.audit_events (request_id, aggregate_type, aggregate_id, event_type, metadata_json) VALUES ($1, 'purchase_request', $2, 'purchase_submitted', $3)",
       [requestId, id, JSON.stringify({ planId: input.planId, wantsCloudSync: input.wantsCloudSync, status, offerVersion: offer?.version ?? null })],
     );
     await connection.query("COMMIT");
@@ -77,7 +77,7 @@ export async function createPurchaseRequest(input: PurchaseRequestInput, request
     // Código de violación de clave única en Postgres: '23505'
     if (error && typeof error === "object" && "code" in error && error.code === "23505") {
       const existingResult = await connection.query<ExistingRequestRow>(
-        "SELECT tracking_id, request_hash, status, expected_amount_minor, currency, offer_expires_at FROM purchase_requests WHERE idempotency_key_hash = $1 LIMIT 1",
+        "SELECT tracking_id, request_hash, status, expected_amount_minor, currency, offer_expires_at FROM landing.purchase_requests WHERE idempotency_key_hash = $1 LIMIT 1",
         [idempotencyHash]
       );
       const existing = existingResult.rows;


### PR DESCRIPTION
## Resumen

- muestra **Iniciar sesión** y **Crear cuenta** explícitamente en la navegación de escritorio y móvil;
- corrige el ejemplo de conexión obsoleto de MySQL y exige el pooler de Supabase en despliegues;
- elimina la dependencia del `search_path` asíncrono;
- califica todas las consultas del portal con el esquema `landing` para compatibilidad con Supavisor;
- añade una prueba contractual para impedir consultas runtime sin esquema.

## Verificación

- `npm test`: 34 pruebas aprobadas;
- `npm run lint`: aprobado;
- `npm run typecheck`: aprobado;
- `npm run build`: aprobado;
- login ficticio de landing en Preview: `401 INVALID_CREDENTIALS`;
- registro sintético en Preview: `202 accepted`, seguido de limpieza transaccional completa;
- login ficticio del panel en Preview: `401 Credenciales inválidas`.

## Operación

- `DATABASE_URL` usa el pooler de Supabase en Production y Preview para `blue-cat` y `blue-cat-34db`;
- la contraseña fue rotada y validada con `SELECT 1`;
- Producción no fue redeplegada manualmente;
- seguimiento del PR #32, que ya fue fusionado.