### PR TITLE
fix: unify account access and stabilize registration

### DIFF
--- a/blue-cat-landing/src/app/globals.css
+++ b/blue-cat-landing/src/app/globals.css
@@ -52,10 +52,9 @@ button, a { -webkit-tap-highlight-color: transparent; }
 .brand { display: inline-flex; align-items: center; gap: .68rem; font-weight: 790; letter-spacing: -.025em; }
 .brand img { width: 2.35rem; height: 2.35rem; object-fit: contain; }
 .desktop-nav { display: flex; align-items: center; gap: 1rem; margin-left: auto; }
-.header-auth { display: flex; align-items: center; gap: .8rem; padding-left: .15rem; }
-.header-auth a:last-child { color: var(--blue); }
 .desktop-nav .button { min-height: 2.8rem; padding: .72rem 1rem; }
 .desktop-nav a { color: #405066; font-size: .93rem; font-weight: 650; }
+.desktop-nav .account-access-link { color: var(--blue); }
 .desktop-nav a:hover { color: var(--blue); }
 .menu-button { display: none; margin-left: auto; width: 2.75rem; height: 2.75rem; align-items: center; justify-content: center; border: 1px solid var(--line); border-radius: .75rem; background: white; }
 .mobile-nav { display: none; padding: 0 0 1rem; }

--- a/blue-cat-landing/src/components/layout/site-header.test.tsx
+++ b/blue-cat-landing/src/components/layout/site-header.test.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SiteHeader } from "./site-header";
+
+describe("SiteHeader", () => {
+  it("offers one combined account access in each navigation", () => {
+    render(<SiteHeader />);
+
+    for (const name of ["Navegación principal", "Navegación móvil"]) {
+      const navigation = screen.getByRole("navigation", { name });
+      expect(within(navigation).getAllByRole("link", { name: "Iniciar sesión o crear cuenta" })).toHaveLength(1);
+      expect(within(navigation).queryByRole("link", { name: "Crear cuenta" })).not.toBeInTheDocument();
+    }
+  });
+});

--- a/blue-cat-landing/src/components/layout/site-header.tsx
+++ b/blue-cat-landing/src/components/layout/site-header.tsx
@@ -17,10 +17,7 @@ export function SiteHeader() {
         </Link>
         <nav className="desktop-nav" aria-label="Navegación principal">
           {navigation.map((item) => <Link key={item.href} href={item.href}>{item.label}</Link>)}
-          <div className="header-auth" role="group" aria-label="Acceso de clientes">
-            <Link href="/ingresar">Iniciar sesión</Link>
-            <Link href="/crear-cuenta">Crear cuenta</Link>
-          </div>
+          <Link className="account-access-link" href="/ingresar">Iniciar sesión o crear cuenta</Link>
           <Link className="button button-primary" href="/comprar">Solicitar licencia</Link>
         </nav>
         <button className="menu-button" type="button" onClick={() => setOpen((value) => !value)} aria-expanded={open} aria-controls="mobile-navigation" aria-label={open ? "Cerrar menú" : "Abrir menú"}>
@@ -29,8 +26,7 @@ export function SiteHeader() {
       </div>
       <nav id="mobile-navigation" className={`container mobile-nav ${open ? "open" : ""}`} aria-label="Navegación móvil">
         {navigation.map((item) => <Link key={item.href} href={item.href} onClick={() => setOpen(false)}>{item.label}</Link>)}
-        <Link href="/ingresar" onClick={() => setOpen(false)}>Iniciar sesión</Link>
-        <Link href="/crear-cuenta" onClick={() => setOpen(false)}>Crear cuenta</Link>
+        <Link href="/ingresar" onClick={() => setOpen(false)}>Iniciar sesión o crear cuenta</Link>
         <Link href="/comprar" onClick={() => setOpen(false)}>Solicitar licencia</Link>
       </nav>
     </header>

--- a/blue-cat-landing/src/components/portal/register-form.test.tsx
+++ b/blue-cat-landing/src/components/portal/register-form.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RegisterForm } from "./register-form";
+
+describe("RegisterForm", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the success state after the asynchronous registration completes", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { accepted: true } }),
+    }));
+
+    render(<RegisterForm termsVersion="terms-2026-07" privacyVersion="privacy-2026-07" />);
+    fireEvent.change(screen.getByLabelText("Nombre completo"), { target: { value: "Codex Verification" } });
+    fireEvent.change(screen.getByLabelText("Correo"), { target: { value: "codex@example.invalid" } });
+    fireEvent.change(screen.getByLabelText("Contraseña"), { target: { value: "Codex-Verify!2026" } });
+    fireEvent.click(screen.getByRole("checkbox", { name: /Acepto los términos/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Crear cuenta segura" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Revisa tu correo");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/blue-cat-landing/src/components/portal/register-form.tsx
+++ b/blue-cat-landing/src/components/portal/register-form.tsx
@@ -28,7 +28,6 @@ export function RegisterForm({ termsVersion, privacyVersion }: { termsVersion: s
       const payload = await response.json() as { error?: { message?: string } };
       if (!response.ok) throw new Error(payload.error?.message || "No pudimos crear la cuenta.");
       setStatus("sent");
-      event.currentTarget.reset();
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "No pudimos crear la cuenta.");
       setStatus("idle");

--- a/blue-cat-landing/vitest.config.ts
+++ b/blue-cat-landing/vitest.config.ts
@@ -3,5 +3,5 @@ import path from "node:path";
 
 export default defineConfig({
   resolve: { alias: { "@": path.resolve(__dirname, "src") } },
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.ts", "src/**/*.test.tsx"] },
 });


### PR DESCRIPTION
## Resumen
- reemplaza los enlaces separados de login/registro por un único acceso: Iniciar sesión o crear cuenta
- elimina el reset posterior al await que causaba Cannot read properties of null (reading 'reset')
- añade regresiones de UI para ambos casos

## Validación
- npm test (36 pruebas)
- npm run lint
- npm run typecheck
- npm run build
- verificación de /comprar en Preview de Vercel